### PR TITLE
Remove linter warnings, fix `div`s in `p` issue

### DIFF
--- a/src/app/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/app/components/breadcrumbs/breadcrumbs.tsx
@@ -1,17 +1,8 @@
 import { Link, useLocation } from 'react-router-dom';
+import { breadcrumbNameMap } from './constants';
 import { buildUrl } from '@/app/services/platform';
 
 import './breadcrumbs.scss';
-
-export const breadcrumbNameMap: Record<string, string> = {
-  courses: 'RS School',
-  nodejs: 'Node.js Course',
-  'javascript-mentoring-program': 'JavaScript Mentoring Program',
-  'javascript-preschool': 'JavaScript Pre-school',
-  angular: 'Angular Course',
-  'aws-cloud-developer': 'AWS Cloud Developer Course',
-  'aws-fundamentals': 'AWS Fundamentals Course',
-};
 
 export const Breadcrumbs = () => {
   const location = useLocation();

--- a/src/app/components/breadcrumbs/constants.ts
+++ b/src/app/components/breadcrumbs/constants.ts
@@ -1,0 +1,9 @@
+export const breadcrumbNameMap: Record<string, string> = {
+  courses: 'RS School',
+  nodejs: 'Node.js Course',
+  'javascript-mentoring-program': 'JavaScript Mentoring Program',
+  'javascript-preschool': 'JavaScript Pre-school',
+  angular: 'Angular Course',
+  'aws-cloud-developer': 'AWS Cloud Developer Course',
+  'aws-fundamentals': 'AWS Fundamentals Course',
+};

--- a/src/app/components/title/index.ts
+++ b/src/app/components/title/index.ts
@@ -1,1 +1,2 @@
-export { Title, TitleType } from './title';
+export { Title } from './title';
+export { TitleType } from './types';

--- a/src/app/components/title/title.test.tsx
+++ b/src/app/components/title/title.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { Title, TitleType } from './title';
+import { Title } from './title';
+import { TitleType } from './types';
 
 describe('Title component', () => {
   it('renders without crashing', () => {

--- a/src/app/components/title/title.tsx
+++ b/src/app/components/title/title.tsx
@@ -1,13 +1,7 @@
 import { PropsWithChildren } from 'react';
+import { TitleType } from './types';
 
 import './title.scss';
-
-export enum TitleType {
-  Regular = 'regular',
-  Big = 'big',
-  Bigger = 'bigger',
-  ExtraBig = 'extra-big',
-}
 
 type TitleProps = PropsWithChildren<{
   text?: string;

--- a/src/app/components/title/types.ts
+++ b/src/app/components/title/types.ts
@@ -1,0 +1,6 @@
+export enum TitleType {
+  Regular = 'regular',
+  Big = 'big',
+  Bigger = 'bigger',
+  ExtraBig = 'extra-big',
+}

--- a/src/app/hooks/use-data-by-name/use-data-by-name.ts
+++ b/src/app/hooks/use-data-by-name/use-data-by-name.ts
@@ -23,7 +23,7 @@ export const useDataByName = <K extends keyof DataMap>(
       }
     };
     fetchData();
-  }, [dataName]);
+  }, [dataName, fetchDataFn]);
 
   return { data, loading, error };
 };

--- a/src/app/hooks/use-title/use-title.ts
+++ b/src/app/hooks/use-title/use-title.ts
@@ -8,8 +8,10 @@ export const useTitle = (title: string) => {
 
     if (document.title !== title) document.title = title;
 
+    const titleElement = originalTitle.current;
+
     return () => {
-      document.title = originalTitle.current;
+      document.title = titleElement;
     };
-  }, [title]);
+  }, [documentDefined, title]);
 };

--- a/src/app/hooks/use-title/use-title.ts
+++ b/src/app/hooks/use-title/use-title.ts
@@ -4,9 +4,13 @@ export const useTitle = (title: string) => {
   const documentDefined = typeof document !== 'undefined';
   const originalTitle = useRef(documentDefined ? document.title : 'RS Site');
   useEffect(() => {
-    if (!documentDefined) return;
+    if (!documentDefined) {
+      return;
+    }
 
-    if (document.title !== title) document.title = title;
+    if (document.title !== title) {
+      document.title = title;
+    }
 
     const titleElement = originalTitle.current;
 

--- a/src/features/home/about/about.tsx
+++ b/src/features/home/about/about.tsx
@@ -15,18 +15,15 @@ export const About = () => {
           together."
           />
           <Paragraph>
-            <div>
-              The Rolling Scopes was founded in 2013 in Minsk as a community of Front-end
-              developers. It has since grown into an enormous international developers community.
-            </div>
-            <br />
-            <div>
-              The Rolling Scopes brings together developers of all levels who are passionate about
-              technologies such as JavaScript, Front-end development, AWS, and more. Currently, many
-              developers around the world recognize The Rolling Scopes for its community-based
-              education program, RS School, along with fascinating events and its groovy mascot,
-              Sloth.
-            </div>
+            The Rolling Scopes was founded in 2013 in Minsk as a community of Front-end developers.
+            It has since grown into an enormous international developers community.
+          </Paragraph>
+          <Paragraph>
+            The Rolling Scopes brings together developers of all levels who are passionate about
+            technologies such as JavaScript, Front-end development, AWS, and more. Currently, many
+            developers around the world recognize The Rolling Scopes for its community-based
+            education program, RS School, along with fascinating events and its groovy mascot,
+            Sloth.
           </Paragraph>
         </div>
         <img className="right picture" src={image} alt="Logo" />

--- a/src/features/home/alumni/alumni.tsx
+++ b/src/features/home/alumni/alumni.tsx
@@ -1,27 +1,7 @@
+import { alumni } from './constants';
 import { Paragraph, Title } from '@/app/components';
 
 import { useWindowSize } from '@/app/hooks';
-
-import aesoft from '@/assets/alumni/aesoft.webp';
-import andersen from '@/assets/alumni/andersen.webp';
-import coherent from '@/assets/alumni/coherent.webp';
-import dataart from '@/assets/alumni/dataart.webp';
-import dott from '@/assets/alumni/dott.webp';
-import elinext from '@/assets/alumni/elinext.webp';
-import epam from '@/assets/alumni/epam.webp';
-import godel from '@/assets/alumni/godel.webp';
-
-import itechart from '@/assets/alumni/itechart.webp';
-
-import miro from '@/assets/alumni/miro.webp';
-import nanosoft from '@/assets/alumni/nanosoft.webp';
-import oxagile from '@/assets/alumni/oxagile.webp';
-import pandadoc from '@/assets/alumni/pandadoc.webp';
-import qulix from '@/assets/alumni/qulix.webp';
-import satellite from '@/assets/alumni/satellite.webp';
-import sberbank from '@/assets/alumni/sberbank.webp';
-import toptal from '@/assets/alumni/toptal.webp';
-import visualfabriq from '@/assets/alumni/visualfabriq.webp';
 
 import './alumni.scss';
 
@@ -29,27 +9,6 @@ export interface AlumniProps {
   id: string;
   image: string;
 }
-
-export const alumni: AlumniProps[] = [
-  { id: 'epam', image: epam },
-  { id: 'toptal', image: toptal },
-  { id: 'oxagile', image: oxagile },
-  { id: 'dott', image: dott },
-  { id: 'andersen', image: andersen },
-  { id: 'godel', image: godel },
-  { id: 'satellite', image: satellite },
-  { id: 'itechart', image: itechart },
-  { id: 'pandadoc', image: pandadoc },
-  { id: 'dataart', image: dataart },
-  { id: 'coherent', image: coherent },
-  { id: 'elinext', image: elinext },
-  { id: 'miro', image: miro },
-  { id: 'qulix', image: qulix },
-  { id: 'visualfabriq', image: visualfabriq },
-  { id: 'sberbank', image: sberbank },
-  { id: 'nanosoft', image: nanosoft },
-  { id: 'aesoft', image: aesoft },
-];
 
 export const Alumni = () => {
   const size = useWindowSize();

--- a/src/features/home/alumni/constants.ts
+++ b/src/features/home/alumni/constants.ts
@@ -1,0 +1,42 @@
+import { AlumniProps } from './alumni';
+import aesoft from '@/assets/alumni/aesoft.webp';
+import andersen from '@/assets/alumni/andersen.webp';
+import coherent from '@/assets/alumni/coherent.webp';
+import dataart from '@/assets/alumni/dataart.webp';
+import dott from '@/assets/alumni/dott.webp';
+import elinext from '@/assets/alumni/elinext.webp';
+import epam from '@/assets/alumni/epam.webp';
+import godel from '@/assets/alumni/godel.webp';
+
+import itechart from '@/assets/alumni/itechart.webp';
+
+import miro from '@/assets/alumni/miro.webp';
+import nanosoft from '@/assets/alumni/nanosoft.webp';
+import oxagile from '@/assets/alumni/oxagile.webp';
+import pandadoc from '@/assets/alumni/pandadoc.webp';
+import qulix from '@/assets/alumni/qulix.webp';
+import satellite from '@/assets/alumni/satellite.webp';
+import sberbank from '@/assets/alumni/sberbank.webp';
+import toptal from '@/assets/alumni/toptal.webp';
+import visualfabriq from '@/assets/alumni/visualfabriq.webp';
+
+export const alumni: AlumniProps[] = [
+  { id: 'epam', image: epam },
+  { id: 'toptal', image: toptal },
+  { id: 'oxagile', image: oxagile },
+  { id: 'dott', image: dott },
+  { id: 'andersen', image: andersen },
+  { id: 'godel', image: godel },
+  { id: 'satellite', image: satellite },
+  { id: 'itechart', image: itechart },
+  { id: 'pandadoc', image: pandadoc },
+  { id: 'dataart', image: dataart },
+  { id: 'coherent', image: coherent },
+  { id: 'elinext', image: elinext },
+  { id: 'miro', image: miro },
+  { id: 'qulix', image: qulix },
+  { id: 'visualfabriq', image: visualfabriq },
+  { id: 'sberbank', image: sberbank },
+  { id: 'nanosoft', image: nanosoft },
+  { id: 'aesoft', image: aesoft },
+];

--- a/src/features/home/school/constants.ts
+++ b/src/features/home/school/constants.ts
@@ -1,0 +1,19 @@
+import { OptionItemProps } from '@/app/components/option-item/option-item';
+
+export const studyOptions: OptionItemProps[] = [
+  {
+    title: 'Teach and empower',
+    description:
+      'We aim to provide education to everyone interested and assist in hiring the best students.',
+  },
+  {
+    title: 'Connect and grow',
+    description:
+      'We strive to connect people, grow together, and build a solid educational community.',
+  },
+  {
+    title: 'Foster mentoring culture',
+    description:
+      'We encourage a culture of mentoring where knowledge is shared and wisdom is passed on.',
+  },
+];

--- a/src/features/home/school/school.test.tsx
+++ b/src/features/home/school/school.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { School, studyOptions } from './school';
+import { studyOptions } from './constants';
+import { School } from './school';
 
 describe('School Component', () => {
   beforeEach(() => {

--- a/src/features/home/school/school.tsx
+++ b/src/features/home/school/school.tsx
@@ -1,33 +1,9 @@
-import {
-  OptionItem,
-  OptionItemProps,
-  Paragraph,
-  SectionLabel,
-  Subtitle,
-  Title,
-} from '@/app/components';
+import { studyOptions } from './constants';
+import { OptionItem, Paragraph, SectionLabel, Subtitle, Title } from '@/app/components';
 
 import image from '@/assets/rs-school.webp';
 
 import './school.scss';
-
-export const studyOptions: OptionItemProps[] = [
-  {
-    title: 'Teach and empower',
-    description:
-      'We aim to provide education to everyone interested and assist in hiring the best students.',
-  },
-  {
-    title: 'Connect and grow',
-    description:
-      'We strive to connect people, grow together, and build a solid educational community.',
-  },
-  {
-    title: 'Foster mentoring culture',
-    description:
-      'We encourage a culture of mentoring where knowledge is shared and wisdom is passed on.',
-  },
-];
 
 export const School = () => (
   <div id="school" className="school container">

--- a/src/features/principles/constants.tsx
+++ b/src/features/principles/constants.tsx
@@ -1,0 +1,23 @@
+import { PrincipleCardProps } from '@/app/components';
+import { OpenSourcePhilosophyIcon, OpenToEveryoneIcon, TeachItForwardIcon } from '@/icons';
+
+export const cards: PrincipleCardProps[] = [
+  {
+    title: 'Open to everyone',
+    description:
+      'Free courses, no obligations, and no contracts. No age limit. Only students’ time and dedication are required. Students can repeatedly attend courses.',
+    icon: <OpenToEveryoneIcon />,
+  },
+  {
+    title: 'Open source philosophy',
+    description:
+      'Our Learning Management System platform and educational materials are publicly available on GitHub and YouTube.',
+    icon: <OpenSourcePhilosophyIcon />,
+  },
+  {
+    title: '"Teach it forward"',
+    description:
+      'Students study at school for free, but we request that they return as mentors to pass on their knowledge to the next generation of students.',
+    icon: <TeachItForwardIcon />,
+  },
+];

--- a/src/features/principles/principles.test.tsx
+++ b/src/features/principles/principles.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it } from 'vitest';
+import { cards } from './constants';
 
-import { Principles, cards } from './principles';
+import { Principles } from './principles';
 
 describe('Principles', () => {
   beforeEach(() => {

--- a/src/features/principles/principles.tsx
+++ b/src/features/principles/principles.tsx
@@ -1,29 +1,7 @@
-import { PrincipleCard, type PrincipleCardProps, Title, TitleType } from '@/app/components';
-
-import { OpenSourcePhilosophyIcon, OpenToEveryoneIcon, TeachItForwardIcon } from '@/icons';
+import { cards } from './constants';
+import { PrincipleCard, Title, TitleType } from '@/app/components';
 
 import './principles.scss';
-
-export const cards: PrincipleCardProps[] = [
-  {
-    title: 'Open to everyone',
-    description:
-      'Free courses, no obligations, and no contracts. No age limit. Only students’ time and dedication are required. Students can repeatedly attend courses.',
-    icon: <OpenToEveryoneIcon />,
-  },
-  {
-    title: 'Open source philosophy',
-    description:
-      'Our Learning Management System platform and educational materials are publicly available on GitHub and YouTube.',
-    icon: <OpenSourcePhilosophyIcon />,
-  },
-  {
-    title: '"Teach it forward"',
-    description:
-      'Students study at school for free, but we request that they return as mentors to pass on their knowledge to the next generation of students.',
-    icon: <TeachItForwardIcon />,
-  },
-];
 
 export const Principles = () => (
   <div className="principles container">


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [x] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

Remove linter warnings:
- warning: Fast refresh only works when a file only exports components -> move const to a separate file
- warning: React Hook useEffect has a missing dependency -> add deps
- warning: The ref value 'originalTitle.current' will likely have changed -> create var and use it in return

Remove `div`s from Paragraph component.

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #88 
- Closes #88 
- Related Issue #95 
- Closes #95 

## Screenshots, Recordings

![Безымянный](https://github.com/rolling-scopes/site/assets/46446962/4d9a8032-5662-4e5b-a0f6-ba0331776015)

## Added/updated tests?

- [x] 👌 Yes
- [ ] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
![323219511-d1585d63-159f-4258-bd95-e1bcdfa13568](https://github.com/rolling-scopes/site/assets/46446962/28cf9057-dd1d-479a-8170-2069418ff0f7)
