### PR TITLE
Fix SCSS-modules import issue

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -42,6 +42,11 @@ module.exports = {
             group: 'object',
             position: 'after'
           },
+          {
+            pattern: '{.,..}/**/*\module.scss',
+            group: 'object',
+            position: 'after'
+          },
         ],
         pathGroupsExcludedImportTypes: ['react', 'react-dom/**'],
         'distinctGroup': false,


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description
Fix issue with imports order for SCSS-modules. Add `.modules.scss` to special group in `import-order` ESLint plugin

## Related Tickets & Documents

- Related Issue #73
- Closes #116 

## Screenshots, Recordings

![photo_2024-04-19_17-31-55](https://github.com/rolling-scopes/site/assets/56927722/e2acf983-0196-4dc6-9b75-6d356e40a2a3)

## Added/updated tests?

- [ ] 👌 Yes
- [x] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help
