### PR TITLE
Fix: fix bug 'iPhone image disproportionately stretched'

### DIFF
--- a/src/features/courses/main/main.scss
+++ b/src/features/courses/main/main.scss
@@ -63,5 +63,7 @@
     max-width: 314px;
     height: auto;
     margin-right: 22px;
+
+    object-fit: contain;
   }
 }

--- a/src/features/courses/mentors/mentors.scss
+++ b/src/features/courses/mentors/mentors.scss
@@ -40,6 +40,7 @@
         img {
           width: 100%;
           height: 100%;
+          object-fit: contain;
         }
       }
     }

--- a/src/features/home/community/community.scss
+++ b/src/features/home/community/community.scss
@@ -39,6 +39,7 @@
       @include media-mobile {
         width: 100%;
         height: auto;
+        object-fit: contain;
       }
 
       width: 390px;

--- a/src/features/home/contribute/contribute.scss
+++ b/src/features/home/contribute/contribute.scss
@@ -52,6 +52,7 @@
       @include media-mobile {
         width: 100%;
         height: auto;
+        object-fit: contain;
       }
 
       width: 358px;
@@ -73,7 +74,6 @@
       margin-top: 24px;
 
       & .option {
-
         @include media-laptop {
           max-width: 600px;
           margin-top: 24px;

--- a/src/features/home/school/school.scss
+++ b/src/features/home/school/school.scss
@@ -28,6 +28,7 @@
       @include media-tablet {
         width: 278px;
         height: auto;
+        object-fit: contain;
       }
 
       width: 347px;

--- a/src/features/home/support/support.scss
+++ b/src/features/home/support/support.scss
@@ -38,6 +38,7 @@
         width: 300px;
         height: auto;
         margin-top: 16px;
+        object-fit: contain;
       }
 
       @include media-tablet {

--- a/src/features/training-program/training-program.scss
+++ b/src/features/training-program/training-program.scss
@@ -75,6 +75,7 @@
         img {
           width: 100%;
           height: min-content;
+          object-fit: contain;
         }
       }
     }

--- a/src/features/training-program/training-program.scss
+++ b/src/features/training-program/training-program.scss
@@ -76,7 +76,7 @@
 
         img {
           width: 100%;
-          height: min-content;
+          // height: min-content; // need to check on mobile
           object-fit: contain;
         }
       }

--- a/src/features/training-program/training-program.scss
+++ b/src/features/training-program/training-program.scss
@@ -47,7 +47,9 @@
       .right {
         @include media-tablet-large {
           align-self: center;
+
           width: 320px;
+          max-width: 60%;
           height: auto;
           max-height: 511px;
         }


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description
Fix bug: 'Images on the iPhone version of the website appear stretched and distorted, losing their original aspect ratio.'

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #109
- Closes #109

## Screenshots, Recordings

![image](https://github.com/rolling-scopes/site/assets/79564962/246d07c4-9d46-485a-904a-23c57d4dd71c)
![image](https://github.com/rolling-scopes/site/assets/79564962/baf5983f-4925-47c2-99f3-2ae20a1b4a73)

## Added/updated tests?

- [ ] 👌 Yes
- [x] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help