### PR TITLE
Fix: layout distortion on zoom out

### DIFF
--- a/src/features/base-layout/components/navbar/navbar.scss
+++ b/src/features/base-layout/components/navbar/navbar.scss
@@ -9,10 +9,6 @@
   top: 0;
   left: 0;
 
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-
   width: 100%;
   height: 64px;
   padding: 8px 40px;
@@ -36,6 +32,17 @@
     border-bottom-left-radius: 0;
     box-shadow: rgb(0 0 0 / 8.2%) 0 1.0260px 8.0694px 0;
   }
+
+}
+
+.navbar-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  max-width: 1440px;
+  height: 100%;
+  margin: 0 auto;
 
   .burger {
     @include media-hover {
@@ -111,9 +118,10 @@
       }
     }
   }
+
 }
 
-.navbar > .menu {
+.navbar-content > .menu {
   position: relative;
   display: flex;
   gap: 28px;

--- a/src/features/base-layout/components/navbar/navbar.tsx
+++ b/src/features/base-layout/components/navbar/navbar.tsx
@@ -53,7 +53,7 @@ export const Navbar = () => {
   }, [width, key, hash, pathname]);
 
   return (
-    <div className={`navbar ${color}`} data-testid="navigation">
+    <nav className={`navbar ${color}`} data-testid="navigation">
       <section className="navbar-content">
         <Link to="/" onClick={() => window.scrollTo({ top: 0 })}>
           <LogoWrapper type="navbar" />
@@ -84,6 +84,6 @@ export const Navbar = () => {
 
         {isMobile && <BurgerMenu isMenuOpen={isMenuOpen} toggleMenu={toggleMenu} />}
       </section>
-    </div>
+    </nav>
   );
 };

--- a/src/features/base-layout/components/navbar/navbar.tsx
+++ b/src/features/base-layout/components/navbar/navbar.tsx
@@ -54,34 +54,36 @@ export const Navbar = () => {
 
   return (
     <div className={`navbar ${color}`} data-testid="navigation">
-      <Link to="/" onClick={() => window.scrollTo({ top: 0 })}>
-        <LogoWrapper type="navbar" />
-      </Link>
+      <section className="navbar-content">
+        <Link to="/" onClick={() => window.scrollTo({ top: 0 })}>
+          <LogoWrapper type="navbar" />
+        </Link>
 
-      {isMobile && (
-        <menu className={`mobile-menu ${isMenuOpen ? 'open' : ''}`} data-testid="mobile-menu">
-          <MobileView type="navbar" />
-        </menu>
-      )}
+        {isMobile && (
+          <menu className={`mobile-menu ${isMenuOpen ? 'open' : ''}`} data-testid="mobile-menu">
+            <MobileView type="navbar" />
+          </menu>
+        )}
 
-      {!isMobile && (
-        <menu className="menu">
-          {navLinks.map((link) => {
-            const isDropdown = link.label === 'RS School';
+        {!isMobile && (
+          <menu className="menu">
+            {navLinks.map((link) => {
+              const isDropdown = link.label === 'RS School';
 
-            return (
-              <NavItem
-                key={link.label}
-                label={link.label}
-                href={isDropdown ? undefined : link.href}
-                dropdown={isDropdown}
-              />
-            );
-          })}
-        </menu>
-      )}
+              return (
+                <NavItem
+                  key={link.label}
+                  label={link.label}
+                  href={isDropdown ? undefined : link.href}
+                  dropdown={isDropdown}
+                />
+              );
+            })}
+          </menu>
+        )}
 
-      {isMobile && <BurgerMenu isMenuOpen={isMenuOpen} toggleMenu={toggleMenu} />}
+        {isMobile && <BurgerMenu isMenuOpen={isMenuOpen} toggleMenu={toggleMenu} />}
+      </section>
     </div>
   );
 };

--- a/src/features/home/numbers/numbers.scss
+++ b/src/features/home/numbers/numbers.scss
@@ -10,6 +10,7 @@
       padding: 40px 16px;
     }
 
+    position: relative;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/features/home/numbers/numbers.scss
+++ b/src/features/home/numbers/numbers.scss
@@ -11,6 +11,7 @@
     }
 
     position: relative;
+
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -30,7 +30,7 @@ li {
 
 .container {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: center;
 
   width: 100%;


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

Now all the blocks are aligned on center on zoom out.

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #149 
- Closes #149 

## Screenshots, Recordings

![FireShot Capture 034 - Home · The Rolling Scopes School - localhost](https://github.com/rolling-scopes/site/assets/46446962/e36da090-e69c-43f7-85e8-c4ed197d2384)
![FireShot Capture 036 - Home · The Rolling Scopes School - localhost](https://github.com/rolling-scopes/site/assets/46446962/6cc357dd-7517-451e-b289-c66f928820f8)

## [optional] What gif best describes this PR or how it makes you feel?
![family-guy-css](https://github.com/rolling-scopes/site/assets/46446962/7b92a153-000f-47b7-874d-5943c4b669b6)


## Added/updated tests?

- [ ] 👌 Yes
- [x] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help
