### PR TITLE
215-feat: Add reset styles file to project

### DIFF
--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -1,0 +1,77 @@
+/*
+Box-sizing model
+ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+/*
+Remove default margin
+ */
+
+* {
+  margin: 0;
+}
+
+/*
+1. Improve text rendering  
+2. Tweaking line-height
+ */
+
+body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  line-height: 1.5;
+}
+
+/* 
+Sensible media defaults
+ */
+
+img,
+picture,
+video,
+canvas,
+svg,
+audio,
+iframe,
+embed,
+object {
+  max-width: 100%;
+}
+
+/*
+Inherit fonts for form controls
+ */
+
+input,
+button,
+textarea,
+select {
+  font: inherit;
+}
+
+/*
+Avoid text overflows
+ */
+
+p,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  overflow-wrap: break-word;
+}
+
+/*
+Create a root stacking context
+ */
+
+#root {
+  isolation: isolate;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     preprocessorOptions: {
       scss: {
         additionalData: `
+          @import "./src/styles/_reset.scss";
           @import "./src/styles/_constants.scss";
           @import "./src/styles/_mixins.scss";
           @import "./src/styles/_placeholders.scss";


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

The _reset.scss file has been added to the project with a minimal reset of CSS settings

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #215
- Closes #215

## Screenshots, Recordings
![reset](https://github.com/rolling-scopes/site/assets/52886210/a829b0ac-37c0-4dc9-8045-4712e001144c)

## Added/updated tests?

- [ ] 👌 Yes
- [x] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help


