### PR TITLE
248-fix: Update block 'Certificate' in 'About the course' section on Courses pages

### DIFF
--- a/src/features/about/about.data.ts
+++ b/src/features/about/about.data.ts
@@ -40,7 +40,7 @@ const angularNodejsAwsFundamentals: (course: string) => AboutInfo[] = () => [
   {
     id: 4,
     title: 'Certificate',
-    info: 'After accomplishing all three stages of education, students will receive an electronic certificate of completion.',
+    info: 'After successful completion of the course, students will receive an electronic certificate of completion.',
     icon: awardIcon,
   },
 ];
@@ -73,7 +73,7 @@ const javaScriptEN: () => AboutInfo[] = () => {
     {
       id: 4,
       title: 'Certificate',
-      info: 'A certificate of successful completion of the course is issued to everybody who pass two stages of training.',
+      info: 'After successful completion of the course, students will receive an electronic certificate of completion.',
       icon: awardIcon,
     },
   ];
@@ -101,7 +101,7 @@ const javaScriptRU: () => AboutInfo[] = () => {
     {
       id: 4,
       title: 'Сертификат',
-      info: 'Сертификат успешного окончания курса выдается всем, кто проходит два этапа обучения.',
+      info: 'Электронный сертификат успешного окончания курса выдается всем, кто проходит два этапа обучения.',
       icon: awardIcon,
     },
   ];
@@ -130,7 +130,7 @@ const javaScriptPreSchoolRU: () => AboutInfo[] = () => {
     {
       id: 4,
       title: 'Сертификат',
-      info: 'При успешном прохождении курса выдается сертификат',
+      info: 'При успешном прохождении курса выдается электронный сертификат.',
       icon: awardIcon,
     },
   ];
@@ -170,7 +170,7 @@ const reactRuAbout: AboutInfo[] = [
   {
     id: 3,
     title: 'Сертификат',
-    info: 'Сертификат об успешном прохождении курсов выдается всем прошедшим два этапа обучения.',
+    info: 'При успешном прохождении курса выдается электронный сертификат.',
     icon: awardIcon,
   },
   {


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

Changed info about certificate in 'About the course' section on Courses pages.

## Related Tickets & Documents

- Related Issue #248 
- Closes #248 

## Screenshots, Recordings

Before
![image](https://github.com/rolling-scopes/site/assets/56927722/0f38a25b-f64c-4d23-ba44-6909c6750ccd)

After
![image](https://github.com/rolling-scopes/site/assets/56927722/af6fe449-df6e-4bdc-96d4-caaf56201741)


## Added/updated tests?

- [ ] 👌 Yes
- [x] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help
