### PR TITLE
202-fix: Loading indicator bug

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -9,7 +9,14 @@ const router = createBrowserRouter(routes);
 function App() {
   return (
     <div className="app-styles">
-      <NextTopLoader color="black" easing="ease-in-out" showSpinner={false} speed={300} />
+      <NextTopLoader
+        color="black"
+        initialPosition={0.0001}
+        crawl={false}
+        easing="ease-in-out"
+        showSpinner={false}
+        speed={300}
+      />
       <RouterProvider router={router} data-testid="router-provider" />
     </div>
   );

--- a/src/app/styles/index.scss
+++ b/src/app/styles/index.scss
@@ -36,7 +36,9 @@ figure {
   display: flex;
   align-items: center;
   justify-content: center;
+
   width: 100%;
+
   text-align: left;
 }
 


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description
- the NextTopLoader is completely triggered when returning to the page after clicking on the link
- changed the parameters passed to the component
- with the parameter initialPosition={0.0} - the component did not work correctly, so the value was set to 0.0001
- empty lines in src/app/styles/index.scss - stylelint:fix 

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #202
- Closes #202

## Screenshots, Recordings

_Please replace this line with any relevant images for UI changes._

## Added/updated tests?

- [ ] 👌 Yes
- [ ] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help


