### PR TITLE
316-fix: docs link fix

### DIFF
--- a/src/entities/courses/ui/general/general.scss
+++ b/src/entities/courses/ui/general/general.scss
@@ -64,7 +64,14 @@
           line-height: 28px;
 
           a {
+            @extend %transition-all;
+
+            color: $color-gray-600;
             text-decoration: underline;
+
+            &:hover {
+              color: $color-gray-400;
+            }
           }
         }
       }

--- a/src/entities/courses/ui/general/general.test.tsx
+++ b/src/entities/courses/ui/general/general.test.tsx
@@ -14,7 +14,7 @@ describe('General', () => {
 
   it('displays the Materials section', () => {
     expect(screen.getByText('Materials')).toBeVisible();
-    expect(screen.getByText('documentation')).toBeVisible();
+    expect(screen.getByText('School documentation')).toBeVisible();
   });
 
   it('displays the Certificate section', () => {

--- a/src/entities/courses/ui/general/general.tsx
+++ b/src/entities/courses/ui/general/general.tsx
@@ -13,8 +13,9 @@ export const General = () => {
             <h2 className="title">Materials</h2>
             <ul className="description">
               <li>
-                School
-                <Link to="https://docs.rs.school">documentation</Link>
+                <Link to="https://docs.rs.school" target="_blank" rel="noopener noreferrer">
+                  School documentation
+                </Link>
               </li>
               <li>All materials are publicly available on YouTube and GitHub</li>
               <li>


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description
- Put all text into link
- split in two words
- added target="_blank" to open in new window and rel="noopener noreferrer" for security
- changed link styles to match prev links in same page but different component
-  changed text in test to match new link

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #316 
- Closes #316 

## Screenshots, Recordings

before 
![image](https://github.com/rolling-scopes/site/assets/119520932/977c5dbe-4207-4a1a-8fe5-c8a4d0efb229)

after
![image](https://github.com/rolling-scopes/site/assets/119520932/b2e04234-e919-4c29-992a-5b512d155f05)


## Added/updated tests?

- [x] 👌 Yes
- [ ] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

