### PR TITLE
286-refactor: delete redundant section titles

### DIFF
--- a/src/widgets/events/events.test.tsx
+++ b/src/widgets/events/events.test.tsx
@@ -18,13 +18,6 @@ describe('Events', () => {
     expect(subtitleElement).toBeVisible();
   });
 
-  it('renders the section label correctly', () => {
-    const { getByText } = renderWithRouter(<Events />);
-    const sectionLabel = getByText('events & meetups');
-
-    expect(sectionLabel).toBeVisible();
-  });
-
   it('renders the paragraph text correctly', () => {
     const { getByText } = renderWithRouter(<Events />);
     const paragraphText = getByText(/we have organized 150\+ events/i);

--- a/src/widgets/events/ui/events.tsx
+++ b/src/widgets/events/ui/events.tsx
@@ -7,7 +7,6 @@ import photo3 from '@/shared/assets/photo-3.webp';
 import { getActualDataList } from '@/shared/helpers/getActualDataList';
 import Image from '@/shared/ui/image';
 import { Paragraph } from '@/shared/ui/paragraph';
-import { SectionLabel } from '@/shared/ui/section-label';
 import { Subtitle } from '@/shared/ui/subtitle';
 import { Title } from '@/shared/ui/title';
 
@@ -33,7 +32,6 @@ export const Events = () => {
     <article id="events" className={cn(cx('events'), 'container')}>
       <div className={cn(cx('events', 'content'), 'content')}>
         <section className={cx('info')}>
-          <SectionLabel label="events & meetups" />
           <Title text="Meet us at events" hasAsterisk />
           <Subtitle text="For years we have been organizing meetups and conferences, where you can always learn something new, share your knowledge, discover new technologies, meet old and find new friends." />
           <Paragraph>

--- a/src/widgets/merch/ui/merch.tsx
+++ b/src/widgets/merch/ui/merch.tsx
@@ -4,7 +4,6 @@ import { ArrowIcon } from '@/shared/icons';
 import Image from '@/shared/ui/image';
 import { LinkCustom } from '@/shared/ui/link-custom';
 import { Paragraph } from '@/shared/ui/paragraph';
-import { SectionLabel } from '@/shared/ui/section-label';
 import { Subtitle } from '@/shared/ui/subtitle';
 import { Title } from '@/shared/ui/title';
 
@@ -14,13 +13,12 @@ export const Merch = () => (
   <div id="merch" className="merch container">
     <div className="merch content column-2">
       <div className="info">
-        <SectionLabel label="merch" />
         <Title text="RS merch" hasAsterisk />
         <Subtitle text="Are you an RS sloth fan and looking for RS merch?" />
         <Paragraph>
-          The wait is almost over as we&apos;re gearing up for the catalog of free web and print assets
-          where you will find all merch collections and can print your own Rolling Scopes t-shirts,
-          stickers etc.
+          The wait is almost over as we&apos;re gearing up for the catalog of free web and print
+          assets where you will find all merch collections and can print your own Rolling Scopes
+          t-shirts, stickers etc.
         </Paragraph>
         <LinkCustom
           href={LINKS.MERCH}


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [x] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

delete redundant section titles that duplicated text from Title component in merch and events.

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #286 
- Closes #286 

## Screenshots, Recordings

before
![image](https://github.com/rolling-scopes/site/assets/119520932/e7dbf145-8057-4a3a-b715-10d55a354ad0)

after
![image](https://github.com/rolling-scopes/site/assets/119520932/d621b393-06d5-45d7-8dce-474d6a36a5d2)


## Added/updated tests?

removed test as Subtitle component is not present on page anymore

