### PR TITLE
325-fix:  course links alignment

### DIFF
--- a/src/widgets/study-path/ui/stage-card/links/links.scss
+++ b/src/widgets/study-path/ui/stage-card/links/links.scss
@@ -2,6 +2,7 @@
   @include media-laptop {
     flex-direction: column;
     gap: 16px;
+    align-items: flex-start;
   }
 
   display: flex;


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description
left alignment of course links on mobile

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #325 
- Closes #325 

## Screenshots, Recordings

before
![image](https://github.com/rolling-scopes/site/assets/119520932/9dfa92f9-148a-40aa-a9a6-5274b063991c)

after
![image](https://github.com/rolling-scopes/site/assets/119520932/e2284abf-85c4-41d9-9e01-517b5d559ca5)


## Added/updated tests?

- [ ] 👌 Yes
- [x] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

