### PR TITLE
Fix/286 delete dublicates headers

### DIFF
--- a/src/widgets/events/events.test.tsx
+++ b/src/widgets/events/events.test.tsx
@@ -18,13 +18,6 @@ describe('Events', () => {
     expect(subtitleElement).toBeVisible();
   });
 
-  it('renders the section label correctly', () => {
-    const { getByText } = renderWithRouter(<Events />);
-    const sectionLabel = getByText('events & meetups');
-
-    expect(sectionLabel).toBeVisible();
-  });
-
   it('renders the paragraph text correctly', () => {
     const { getByText } = renderWithRouter(<Events />);
     const paragraphText = getByText(/we have organized 150\+ events/i);

--- a/src/widgets/events/ui/events.tsx
+++ b/src/widgets/events/ui/events.tsx
@@ -7,7 +7,6 @@ import photo3 from '@/shared/assets/photo-3.webp';
 import { getActualDataList } from '@/shared/helpers/getActualDataList';
 import Image from '@/shared/ui/image';
 import { Paragraph } from '@/shared/ui/paragraph';
-import { SectionLabel } from '@/shared/ui/section-label';
 import { Subtitle } from '@/shared/ui/subtitle';
 import { Title } from '@/shared/ui/title';
 
@@ -33,7 +32,6 @@ export const Events = () => {
     <article id="events" className={cn(cx('events'), 'container')}>
       <div className={cn(cx('events', 'content'), 'content')}>
         <section className={cx('info')}>
-          <SectionLabel label="events & meetups" />
           <Title text="Meet us at events" hasAsterisk />
           <Subtitle text="For years we have been organizing meetups and conferences, where you can always learn something new, share your knowledge, discover new technologies, meet old and find new friends." />
           <Paragraph>

--- a/src/widgets/merch/ui/merch.tsx
+++ b/src/widgets/merch/ui/merch.tsx
@@ -4,7 +4,6 @@ import { ArrowIcon } from '@/shared/icons';
 import Image from '@/shared/ui/image';
 import { LinkCustom } from '@/shared/ui/link-custom';
 import { Paragraph } from '@/shared/ui/paragraph';
-import { SectionLabel } from '@/shared/ui/section-label';
 import { Subtitle } from '@/shared/ui/subtitle';
 import { Title } from '@/shared/ui/title';
 
@@ -14,7 +13,6 @@ export const Merch = () => (
   <div id="merch" className="merch container">
     <div className="merch content column-2">
       <div className="info">
-        <SectionLabel label="merch" />
         <Title text="RS merch" hasAsterisk />
         <Subtitle text="Are you an RS sloth fan and looking for RS merch?" />
         <Paragraph>


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

Delete the duplicates of headers "events and meetups"  and "merch"

## Related Tickets & Documents

closes #286

## Screenshots, Recordings

<img width="1171" alt="Screenshot 2024-06-24 at 13 27 28" src="https://github.com/rolling-scopes/site/assets/112382387/011a6c5c-cb92-468e-a117-a5d09c2be4dc">

and

<img width="625" alt="Screenshot 2024-06-24 at 13 28 20" src="https://github.com/rolling-scopes/site/assets/112382387/e70fcdf5-7855-457f-93a6-3cfaa0151a0c">

## Added/updated tests?

- [x ] 👌 Yes
- [ ] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
