### PR TITLE
299-fix: focus on course card differs

### DIFF
--- a/src/entities/courses/ui/course-card/course-card.scss
+++ b/src/entities/courses/ui/course-card/course-card.scss
@@ -34,7 +34,7 @@
     align-items: center;
 
     width: 100%;
-    height: min-content;
+    height: 100%;
     padding: 32px 24px 24px;
 
     background-color: #eef3fe;


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [x] 🐛 Bug Fix

## Description
on  some resolutions and some cards with lower content height there was a second chin on hover effect cuz of height: min-content. changed it to 100% to be consistent

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #299 
- Closes #299 

## Screenshots, Recordings

![image](https://github.com/rolling-scopes/site/assets/119520932/c8b979a2-c71a-4241-8435-f7d8bf78bf1f)

## Added/updated tests?

- [x] 🙅‍♂️ No, because they aren't needed




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the course card layout to use a fixed height for more consistent appearance across different devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->