### PR TITLE
283-refactor: refactor RS redirect

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: build
         env:
-          HOST: 'https://rollingscopes.com'
+          HOST: 'https://rs.school'
         run: |
           npm install
           npm run build

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -7,11 +7,6 @@ import './app.scss';
 const router = createBrowserRouter(routes);
 
 function App() {
-  // If we are on https://rollingscopes.com/, a redirect to https://rs.school/ is triggered.
-  if (window.location.hostname.includes('rollingscopes.com')) {
-    window.location.href = 'https://rs.school';
-  }
-
   return (
     <div className="app-styles">
       <NextTopLoader


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [x] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

Refactored redirect 'https://rollingscopes.com/' to 'https://rs.school/'. To check if the redirect works:
- follow the link 'https://pr342.rollingscopes.com/community';
- an automatic redirect to 'https://rs.school/' will take place.

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #283

## Added/updated tests?

- [ ] 👌 Yes
- [x] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the production deployment environment to use `https://rs.school` instead of `https://rollingscopes.com`.

- **Refactor**
  - Removed unnecessary redirect logic from `rollingscopes.com` to `rs.school`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->