### PR TITLE
336-feat: configure workflow for lighthouse to run on deployments

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,59 @@
+name: Lighthouse test
+
+on:
+  repository_dispatch:
+    types: [preview-created]
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install && npm install -g @lhci/cli@0.14.x
+
+      - name: Run Lighthouse
+        run: lhci autorun --collect.url=https://pr${{ github.event.client_payload.number }}.rs.school
+
+      - name: Upload Lighthouse artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report
+          path: '.lighthouseci/*'
+
+      - name: Generate Lighthouse report summary
+        id: generate_report
+        run: |
+          REPORT_PATH=$(ls .lighthouseci/lhr-*.json | head -n 1)
+          FINAL_URL=$(jq -r '.finalUrl' "$REPORT_PATH")
+          LINKS_PATH=$(ls .lighthouseci/links.json | head -n 1)
+          REPORT_URL=$(jq -r --arg FINAL_URL "$FINAL_URL" '.[$FINAL_URL]' "$LINKS_PATH")
+          PERFORMANCE=$(jq -r '.categories.performance.score * 100' "$REPORT_PATH")
+          ACCESSIBILITY=$(jq -r '.categories.accessibility.score * 100' "$REPORT_PATH")
+          BEST_PRACTICES=$(jq -r '.categories["best-practices"].score * 100' "$REPORT_PATH")
+          SEO=$(jq -r '.categories.seo.score * 100' "$REPORT_PATH")
+          echo "performance=$PERFORMANCE" >> $GITHUB_OUTPUT
+          echo "accessibility=$ACCESSIBILITY" >> $GITHUB_OUTPUT
+          echo "bestPractices=$BEST_PRACTICES" >> $GITHUB_OUTPUT
+          echo "seo=$SEO" >> $GITHUB_OUTPUT
+          echo "reportUrl=$REPORT_URL" >> $GITHUB_OUTPUT
+
+      - name: Post Lighthouse results to PR
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.client_payload.number }}
+          body: |
+            **Lighthouse Report**:
+            - Performance: ${{ steps.generate_report.outputs.performance }} / 100
+            - Accessibility: ${{ steps.generate_report.outputs.accessibility }} / 100
+            - Best Practices: ${{ steps.generate_report.outputs.bestPractices }} / 100
+            - SEO: ${{ steps.generate_report.outputs.seo }} / 100
+
+            [View detailed report](${{ steps.generate_report.outputs.reportUrl }})

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,8 @@
+{
+  "ci": {
+    "collect": { "numberOfRuns": 1 },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [x] 🍕 Feature

## Description

- [x] Integrate Lighthouse tests into the current CI/CD pipeline using GitHub Actions.
- [x] Configure tests to run on PR deployment.
- [x] Save Lighthouse reports as CI/CD build artifacts.
- [x] Set up notifications for test results in PR comments.

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #336 
- Closes #336 

## Added/updated tests?

- [x] 🙅‍♂️ No, because they aren't needed


## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
