### PR TITLE
420-fix: Disable embedding of svg images into js bundle

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [react()],
   build: {
     outDir: 'build',
+    assetsInlineLimit: 0,
   },
   define: {
     'process.env.RS_SCHOOL_HOST': JSON.stringify(process.env.RS_SCHOOL_HOST || ''),


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

Correct vite config. Now all svg images will be loaded as separate files.

## Related Tickets & Documents
- Related Issue #420 
- Closes #420

## Screenshots, Recordings

Before and After
![image](https://github.com/user-attachments/assets/983e6baf-ff6e-4ea0-bdd9-c755563f83fb)


## Added/updated tests?

- [ ] 👌 Yes
- [x] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

## [optional] Are there any post deployment tasks we need to perform?
none

## [optional] What gif best describes this PR or how it makes you feel?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option to enhance asset handling during the build process.
	- Disabling asset inlining allows for greater control over how assets are processed and served. 

This change may lead to larger output files as all assets will be treated as external resources, optimizing deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->