### PR TITLE
431-fix: Correct behavior of husky precommit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npm run precommit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run precommit

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -40,5 +40,3 @@ then
   echo "-"
   echo "-" "precommit": "concurrently \"chmod +x .husky/pre-commit\" \"npx lint-staged\" \"npm:build\"",
 fi
-
-npm run precommit

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -38,7 +38,6 @@ then
   echo "The name of your commit has been changed to '$MODIFIED_MSG' according to the styleguide 😎"
   echo "-"
   echo "-"
-  echo "-" "precommit": "concurrently \"chmod +x .husky/pre-commit\" \"npx lint-staged\" \"npm:build\"",
 fi
 
 npm run build

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -38,6 +38,7 @@ then
   echo "The name of your commit has been changed to '$MODIFIED_MSG' according to the styleguide 😎"
   echo "-"
   echo "-"
+  echo "-"
 fi
 
 npm run build

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -40,3 +40,5 @@ then
   echo "-"
   echo "-" "precommit": "concurrently \"chmod +x .husky/pre-commit\" \"npx lint-staged\" \"npm:build\"",
 fi
+
+npm run build

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:playWright": "npx playwright test",
     "test:playWrightWithUpdate": "npx playwright test --update-snapshots",
     "coverage": "vitest run --coverage",
-    "precommit": "concurrently \"npx lint-staged\" \"npm:build\"",
+    "precommit": "npx lint-staged && npm run build",
     "prepare": "husky"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:playWright": "npx playwright test",
     "test:playWrightWithUpdate": "npx playwright test --update-snapshots",
     "coverage": "vitest run --coverage",
-    "precommit": "npx lint-staged && npm run build",
+    "precommit": "npx lint-staged",
     "prepare": "husky"
   },
   "dependencies": {


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

Correct behavior of husky precommit, now it runs npx lint-staged and changes files before making the commit itself.

## Related Tickets & Documents

- Related Issue #431
- Closes #431

## Screenshots, Recordings

![precommit-error-fix](https://github.com/user-attachments/assets/6e79e5d2-e367-4af8-9770-219fec86666a)


## Added/updated tests?

- [ ] 👌 Yes
- [x] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

## [optional] Are there any post deployment tasks we need to perform?
no

## [optional] What gif best describes this PR or how it makes you feel?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a pre-commit hook to run linting checks before commits.
  
- **Changes**
	- Simplified the pre-commit script to focus solely on linting.
	- Updated the prepare-commit-msg script to run the build process instead of combined tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->