### PR TITLE
458-fix: Nav item drops active state

### DIFF
--- a/src/app/layouts/base-layout/components/header/nav-item/nav-item.tsx
+++ b/src/app/layouts/base-layout/components/header/nav-item/nav-item.tsx
@@ -35,7 +35,6 @@ export const NavItem = ({ label, href, dropdownInner }: NavItemProps) => {
         }
         onMouseLeave={onClose}
         onMouseEnter={onOpen}
-        end
       >
         <p className={cx('label')}>{label}</p>
         {dropdownInner && (


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [x] 🐛 Bug Fix

## Description

save active state for navitem if child route is active.

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #458 
- Closes #458 


## Added/updated tests?

- [x] 🙅‍♂️ No, because they aren't needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the `end` prop from the `NavItem` component to streamline its interface and improve functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->