### PR TITLE
fix: 476 - add margin bottom to option-description

### DIFF
--- a/src/widgets/option-item/ui/option-item.scss
+++ b/src/widgets/option-item/ui/option-item.scss
@@ -30,7 +30,7 @@
 }
 
 .option-description {
-  margin: 16px 0 0;
+  margin: 16px 0 24px;
 
   font-size: 18px;
   font-weight: $font-weight-regular;


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [ x ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

fix margin in option-item component

## Related Tickets & Documents

- Closes #476 

## Screenshots, Recordings

Before:

![photo_2024-09-01 17 35 09](https://github.com/user-attachments/assets/dbd17688-3ecb-4a56-b6c2-539dff25d937)

After:

<img width="1077" alt="Screenshot 2024-09-01 at 18 02 37" src="https://github.com/user-attachments/assets/6e1788e1-f5e2-4600-b13b-8571cfcaf33b">



## Added/updated tests?

- [ ] 👌 Yes
- [ x ] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
