### PR TITLE
271-refactor: Add width and height to header icons

### DIFF
--- a/src/app/layouts/base-layout/components/header/nav-item/nav-item.module.scss
+++ b/src/app/layouts/base-layout/components/header/nav-item/nav-item.module.scss
@@ -31,7 +31,7 @@
     background-color: $color-black;
   }
 
-  & .label {
+  .label {
     @extend %transition-all;
 
     font-family: Inter, sans-serif;
@@ -49,8 +49,6 @@
     .dropdown-arrow {
       @extend %transition-all;
 
-      width: 16px;
-      height: 17px;
       margin-left: 10px;
 
       > img {

--- a/src/app/layouts/base-layout/components/header/nav-item/nav-item.module.scss
+++ b/src/app/layouts/base-layout/components/header/nav-item/nav-item.module.scss
@@ -52,6 +52,11 @@
       width: 16px;
       height: 17px;
       margin-left: 10px;
+
+      > img {
+        width: 16px;
+        height: 16px;
+      }
     }
 
     &.rotate .dropdown-arrow {


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [x] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

Added `width` and `height` to `dropdown-icon` in the `header` `menu-item`.

## Related Tickets & Documents

- Related Issue #271 
- Closes #271 

## Screenshots, Recordings



## Added/updated tests?

- [ ] 👌 Yes
- [x] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
	- Simplified the styling for the navigation component's label and improved image sizing within the dropdown, ensuring consistent dimensions and enhancing visual consistency across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->