### PR TITLE
493-refactor: Replace font family

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&display=swap" rel="stylesheet" />  
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="RS School offers free, community-driven education courses run by The Rolling Scopes developer community since 2013. Enhance your web development, JavaScript, and front-end skills with us." />
   <title>RS Site</title>

--- a/src/app/layouts/base-layout/components/header/nav-item/nav-item.module.scss
+++ b/src/app/layouts/base-layout/components/header/nav-item/nav-item.module.scss
@@ -34,7 +34,7 @@
   & .label {
     @extend %transition-all;
 
-    font-family: Inter, sans-serif;
+    font-family: $font-primary;
     font-size: 16px;
     font-weight: $font-weight-regular;
     line-height: 20px;

--- a/src/app/styles/_constants.scss
+++ b/src/app/styles/_constants.scss
@@ -6,7 +6,8 @@ $mobile-landscape-width: 568px;
 $mobile-width: 375px;
 
 // font-family
-$font-primary: 'Inter', sans-serif;
+$font-primary: -apple-system, blinkmacsystemfont, 'Segoe UI', 'Noto Sans', helvetica, arial,
+  sans-serif;
 
 // font weights
 $font-weight-light: 300;

--- a/src/widgets/hero/ui/hero.scss
+++ b/src/widgets/hero/ui/hero.scss
@@ -66,7 +66,7 @@
   .subtitle {
     margin: 0;
 
-    font-family: Inter-Medium, Inter, sans-serif;
+    font-family: $font-primary;
     font-size: 20px;
     font-weight: $font-weight-medium;
     line-height: 26px;


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [x] 🧑‍💻 Code Refactor

## Description
Replaced the Inter font family with system fonts.

## Related Tickets & Documents

- Related Issue #493 
- Closes #493 

## Screenshots, Recordings
 - Link to screenshots Before/After for mac, windows, iPhone, Android: 
[https://www.figma.com/design/rF0bjhIoxrIw2GFOeRvxEU/RS?node-id=7-1231&t=jhaHCE6RziOk6VAC-1](https://www.figma.com/design/rF0bjhIoxrIw2GFOeRvxEU/RS?node-id=7-1231&t=jhaHCE6RziOk6VAC-1)

 - Lighthouse
![Screenshot 2024-09-05 130306](https://github.com/user-attachments/assets/a6ba20d9-4876-49fe-a201-ccbedd84daa6)

## Added/updated tests?

- [x] 🙅‍♂️ No, because they aren't needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Styling Updates**
	- Removed the Google Fonts link for "Inter," affecting the webpage's font presentation.
	- Updated font management by using a variable for the navigation item's font-family.
	- Enhanced the primary font stack to include system fonts for improved performance and compatibility.
	- Centralized font-family definition for the subtitle class in the hero component, improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->