### PR TITLE
500-refactor: Widget angular topics

### DIFF
--- a/src/widgets/angular-topics/constants.ts
+++ b/src/widgets/angular-topics/constants.ts
@@ -1,0 +1,12 @@
+export const topicsList = [
+  'TypeScript',
+  'Components',
+  'Directives & Pipes',
+  'Modules & Services, Dependency Injection',
+  'Routing',
+  'RxJS & Observables',
+  'HTTP',
+  'Forms',
+  'Redux & NgRx',
+  'Unit Testing',
+];

--- a/src/widgets/angular-topics/ui/angular-topics.test.tsx
+++ b/src/widgets/angular-topics/ui/angular-topics.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AngularTopics } from './angular-topics';
+
+describe('AngularTopics component', () => {
+  it('renders without crashing', () => {
+    render(<AngularTopics />);
+    const angularTopics = screen.getByTestId('angular-topics');
+
+    expect(angularTopics).toBeVisible();
+  });
+
+  it('displays the title with correct text', () => {
+    render(<AngularTopics />);
+    const title = screen.getByTestId('widget-title');
+
+    expect(title).toBeVisible();
+    expect(title).toHaveTextContent('Topics Covered:');
+  });
+
+  it('displays topics list', () => {
+    render(<AngularTopics />);
+    const list = screen.getByTestId('list');
+
+    expect(list).toBeVisible();
+  });
+});

--- a/src/widgets/angular-topics/ui/angular-topics.test.tsx
+++ b/src/widgets/angular-topics/ui/angular-topics.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { AngularTopics } from './angular-topics';
+import { topicsList } from '../constants';
 
 describe('AngularTopics component', () => {
   it('renders without crashing', () => {
@@ -18,10 +19,11 @@ describe('AngularTopics component', () => {
     expect(title).toHaveTextContent('Topics Covered:');
   });
 
-  it('displays topics list', () => {
+  it('displays the topics list with correct text', () => {
     render(<AngularTopics />);
     const list = screen.getByTestId('list');
 
     expect(list).toBeVisible();
+    expect(list).toHaveTextContent(topicsList.join(''));
   });
 });

--- a/src/widgets/angular-topics/ui/angular-topics.tsx
+++ b/src/widgets/angular-topics/ui/angular-topics.tsx
@@ -9,7 +9,7 @@ const cx = classNames.bind(styles);
 
 export const AngularTopics = () => {
   return (
-    <section className={cx('angular-topics', 'container')}>
+    <section className={cx('angular-topics', 'container')} data-testid="angular-topics">
       <article className={cx('content', 'angular-topics-content')}>
         <WidgetTitle size="medium" mods="asterisk">Topics Covered:</WidgetTitle>
         <List data={topicsList} />

--- a/src/widgets/angular-topics/ui/angular-topics.tsx
+++ b/src/widgets/angular-topics/ui/angular-topics.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames/bind';
+import { topicsList } from '../constants';
 import { List } from '@/shared/ui/list';
 import { WidgetTitle } from '@/shared/ui/widget-title';
 
@@ -7,19 +8,6 @@ import styles from './angular-topics.module.scss';
 const cx = classNames.bind(styles);
 
 export const AngularTopics = () => {
-  const topicsList = [
-    'TypeScript',
-    'Components',
-    'Directives & Pipes',
-    'Modules & Services, Dependency Injection',
-    'Routing',
-    'RxJS & Observables',
-    'HTTP',
-    'Forms',
-    'Redux & NgRx',
-    'Unit Testing',
-  ];
-
   return (
     <section className={cx('angular-topics', 'container')}>
       <article className={cx('content', 'angular-topics-content')}>


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [x] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description
Angular topics component refactor:

- moved all the constants inside the `constants.ts` file
- added tests

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #500, #347
- Closes #500 

## Added/updated tests?

- [x] 👌 Yes
- [ ] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a centralized list of Angular topics for improved consistency across the application.
	- Enhanced the `AngularTopics` component to utilize the new topics list, improving maintainability.

- **Tests**
	- Added a suite of unit tests for the `AngularTopics` component to ensure proper rendering and content display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->