### PR TITLE
511-feat: Simplify course titles

### DIFF
--- a/src/pages/javascript-en.tsx
+++ b/src/pages/javascript-en.tsx
@@ -13,7 +13,7 @@ const COURSE_NAME = 'js / front-end en';
 export const JavaScriptEn = () => {
   return (
     <>
-      <CourseMain courseName={COURSE_NAME} type="Mentoring Program EN" />
+      <CourseMain courseName={COURSE_NAME} />
       <Breadcrumbs />
       <TrainingProgram courseName={COURSE_NAME} />
       <About courseName={COURSE_NAME} />

--- a/src/pages/javascript-ru.tsx
+++ b/src/pages/javascript-ru.tsx
@@ -17,7 +17,7 @@ export const JavaScriptRu = () => {
 
   return (
     <>
-      <CourseMain courseName={COURSE_NAME} type="Менторская программа RU" lang={lang} />
+      <CourseMain courseName={COURSE_NAME} lang={lang} />
       <Breadcrumbs />
       <TrainingProgram courseName={COURSE_NAME} lang={lang} />
       <About courseName={COURSE_NAME} type={lang} />

--- a/src/widgets/breadcrumbs/constants.ts
+++ b/src/widgets/breadcrumbs/constants.ts
@@ -3,13 +3,13 @@ import { BreadcrumbNameMap } from './breadcrumbs.types';
 export const breadcrumbNameMap: BreadcrumbNameMap = {
   courses: 'Courses',
   nodejs: 'Node.js Course',
-  javascript: 'JavaScript Mentoring Program',
-  'javascript-ru': 'JavaScript Mentoring Program RU',
+  javascript: 'JavaScript Course',
+  'javascript-ru': 'JavaScript Course RU',
   'javascript-preschool-ru': 'JavaScript Pre-school RU',
   angular: 'Angular Course',
   'aws-cloud-developer': 'AWS Cloud Developer Course',
   'aws-fundamentals': 'AWS Fundamentals Course',
-  reactjs: 'React course',
+  reactjs: 'React Course',
   community: 'Community',
   'aws-devops': 'AWS DevOps',
 } as const;

--- a/src/widgets/course-main/course-main.tsx
+++ b/src/widgets/course-main/course-main.tsx
@@ -18,7 +18,7 @@ import styles from './course-main.module.scss';
 interface CourseMainProps {
   courseName: string;
   lang?: 'ru' | 'en';
-  type?: 'Mentoring Program EN' | 'Pre-school RU' | 'Менторская программа RU';
+  type?: 'Pre-school RU';
 }
 
 const localizedContent = {


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description
Changed JS/FE course titles

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #511 
- Closes #511 

## Screenshots, Recordings

![js-en](https://github.com/user-attachments/assets/15d46cab-e7db-47f1-b952-897458558116)

![js-ru](https://github.com/user-attachments/assets/972e45a8-93d0-43f9-b907-7594c56ff5de)

## Added/updated tests?

- [ ] 👌 Yes
- [x] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified component usage by removing the `type` prop from `CourseMain` in both English and Russian JavaScript course pages.
	- Updated breadcrumb display names for improved clarity: 
		- "JavaScript Mentoring Program" to "JavaScript Course"
		- "JavaScript Mentoring Program RU" to "JavaScript Course RU"
		- Corrected capitalization for "React course" to "React Course".

- **Bug Fixes**
	- Restricted `type` property in `CourseMainProps` to enhance consistency in component behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->