### PR TITLE
fix: 553 - fix broken links

### DIFF
--- a/dev-data/about.data.tsx
+++ b/dev-data/about.data.tsx
@@ -70,10 +70,9 @@ const javaScriptEN: () => AboutInfo[] = () => {
       info: (
         <p>
           The Mentors and trainers of our school are front-end and javascript developers from
-          different companies/countries. How to
+          different companies/countries.
           {' '}
-          <LinkCustom href="/courses#mentors-wanted">become a mentor</LinkCustom>
-          ?
+          <LinkCustom href="/#mentors-wanted">How to become a mentor?</LinkCustom>
         </p>
       ),
       icon: planetIcon,
@@ -160,7 +159,9 @@ const reactEn: AboutInfo[] = javaScriptEN().map((item) => {
           <li>
             School
             {' '}
-            <LinkCustom href="https://docs.rs.school" external>documentation</LinkCustom>
+            <LinkCustom href="https://docs.rs.school" external>
+              documentation
+            </LinkCustom>
           </li>
           <li>All materials are publicly available on the YouTube channel and GitHub</li>
         </ul>
@@ -175,7 +176,9 @@ const reactEn: AboutInfo[] = javaScriptEN().map((item) => {
         <p>
           Throughout the course, we mostly use
           {' '}
-          <LinkCustom href={DISCORD_LINKS['react']} external>Discord chat</LinkCustom>
+          <LinkCustom href={DISCORD_LINKS['react']} external>
+            Discord chat
+          </LinkCustom>
           .
         </p>
       ),
@@ -208,7 +211,9 @@ const reactRuAbout: AboutInfo[] = [
       <p>
         Throughout the course, we mostly use
         {' '}
-        <LinkCustom href="https://docs.rs.school" external>Документация школы</LinkCustom>
+        <LinkCustom href="https://docs.rs.school" external>
+          Документация школы
+        </LinkCustom>
         . Все материалы находятся в открытом доступе на YouTube и GitHub.Также предлагаем
         ознакомиться с конспектом первого этапа обучения.
       </p>

--- a/src/shared/ui/widget-title/widget-title.tsx
+++ b/src/shared/ui/widget-title/widget-title.tsx
@@ -4,8 +4,8 @@ import classNames from 'classnames/bind';
 
 import styles from './widget-title.module.scss';
 
-type WidgetTitleProps = Pick<HTMLAttributes<HTMLHeadingElement>, 'className' | 'children'>
-  & VariantProps<typeof widgetTitleVariants>;
+type WidgetTitleProps = Pick<HTMLAttributes<HTMLHeadingElement>, 'className' | 'children' | 'id'> &
+  VariantProps<typeof widgetTitleVariants>;
 
 export const cx = classNames.bind(styles);
 

--- a/src/widgets/mentors-wanted/ui/mentors-wanted.tsx
+++ b/src/widgets/mentors-wanted/ui/mentors-wanted.tsx
@@ -15,7 +15,9 @@ export const MentorsWanted = () => {
     <section className={cx('mentors-wanted', 'container')}>
       <article className={classNames('content', cx('content'))}>
         <div className={cx('content-left')}>
-          <WidgetTitle mods="lines">Mentors Wanted!</WidgetTitle>
+          <WidgetTitle id="mentors-wanted" mods="lines">
+            Mentors Wanted!
+          </WidgetTitle>
           <Paragraph>
             If&nbsp;you are interested in mentoring our students, please go through the
             {' '}

--- a/src/widgets/required/ui/required.tsx
+++ b/src/widgets/required/ui/required.tsx
@@ -29,7 +29,11 @@ export const Required = ({ courseName }: RequiredProps) => {
   return (
     <section className="required container">
       <div className="required content info-wrapper">
-        <WidgetTitle mods="asterisk">
+        <WidgetTitle
+          // id is used on WeAreCommunity for direct link
+          id="basic-knowledge"
+          mods="asterisk"
+        >
           {title}
         </WidgetTitle>
 


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

Fixed broken links:

- link 'How to become a mentor?';
- link to 'What you should know before starting' on WeAreCommunity (added anchor '#basic-knowledge' to the section).

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #553
- Closes #553

## Screenshots, Recordings

![image](https://github.com/user-attachments/assets/4a888d97-b204-4bd0-8590-d3e604396c82)
![image](https://github.com/user-attachments/assets/7d15d3ed-a616-46e5-82f2-86f56f0e7303)

## Added/updated tests?

- [ ] 👌 Yes
- [x] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help