### PR TITLE
fix: 371 - semantic headers on course pages

### DIFF
--- a/src/shared/ui/widget-title/widget-title.test.tsx
+++ b/src/shared/ui/widget-title/widget-title.test.tsx
@@ -17,9 +17,16 @@ describe('WidgetTitle component', () => {
     expect(title).toBeVisible();
   });
 
-  it('displays h2 tag', () => {
+  it('displays h2 tag by default', () => {
     render(<WidgetTitle />);
     const element = screen.getByRole('heading', { level: 2 });
+
+    expect(element).toBeInTheDocument();
+  });
+
+  it('displays h1 tag if needed', () => {
+    render(<WidgetTitle as="h1" />);
+    const element = screen.getByRole('heading', { level: 1 });
 
     expect(element).toBeInTheDocument();
   });

--- a/src/shared/ui/widget-title/widget-title.tsx
+++ b/src/shared/ui/widget-title/widget-title.tsx
@@ -4,8 +4,10 @@ import classNames from 'classnames/bind';
 
 import styles from './widget-title.module.scss';
 
-type WidgetTitleProps = Pick<HTMLAttributes<HTMLHeadingElement>, 'className' | 'children' | 'id'> &
-  VariantProps<typeof widgetTitleVariants>;
+type WidgetTitleProps = Pick<HTMLAttributes<HTMLDivElement>, 'className' | 'children' | 'id'> &
+  VariantProps<typeof widgetTitleVariants> & {
+    as?: 'h1' | 'h2' | 'h3';
+  };
 
 export const cx = classNames.bind(styles);
 
@@ -27,9 +29,9 @@ const widgetTitleVariants = cva(cx('widget-title'), {
   },
 });
 
-export const WidgetTitle = ({ children, size, mods, className }: WidgetTitleProps) => {
+export const WidgetTitle = ({ children, size, mods, className, as: Component = 'h2' }: WidgetTitleProps) => {
   return (
-    <h2
+    <Component
       className={widgetTitleVariants({
         size,
         mods,
@@ -38,6 +40,6 @@ export const WidgetTitle = ({ children, size, mods, className }: WidgetTitleProp
       data-testid="widget-title"
     >
       {children}
-    </h2>
+    </Component>
   );
 };

--- a/src/widgets/course-main/course-main.tsx
+++ b/src/widgets/course-main/course-main.tsx
@@ -46,7 +46,7 @@ export const CourseMain = ({ courseName, lang = 'en', type }: CourseMainProps) =
         <Image className={styles.icon} src={secondaryIcon} alt={title} lazy={false} />
         <div className={styles.info}>
           <SectionLabel>{status}</SectionLabel>
-          <WidgetTitle>{`${altTitle || title} Course`}</WidgetTitle>
+          <WidgetTitle as="h1">{`${altTitle || title} Course`}</WidgetTitle>
           {type && (
             <Subtitle fontSize="small" color="black">
               {type}


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

## Related Tickets & Documents
Added `as` prop to `WidgetTitle` to improve semantic of course pages

- Closes #371 

## Screenshots, Recordings

_Please replace this line with any relevant images for UI changes._

## Added/updated tests?

- [x] 👌 Yes
- [ ] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The `WidgetTitle` component now supports rendering as different heading levels (`h1`, `h2`, `h3`) based on user specifications.
  
- **Bug Fixes**
	- Clarified test case naming for better understanding of default rendering behavior.

- **Documentation**
	- Updated documentation to reflect the new optional `as` property in `WidgetTitleProps`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->