### PR TITLE
614-fix: Pre school subtitle

### DIFF
--- a/dev-data/about-course.data.tsx
+++ b/dev-data/about-course.data.tsx
@@ -14,23 +14,33 @@ type ContentMap = {
   [key in CourseNamesChannels]: AboutCourseInfo[];
 };
 
+const enIntro = {
+  title: 'About the course',
+  linkLabel: 'Become a student',
+  paragraph: null,
+};
+const ruIntro = {
+  title: 'О курсе',
+  linkLabel: 'Cтать студентом',
+  paragraph: null,
+};
+const preSchoolIntro = {
+  title: 'JS/Frontend-разработка. Подготовительный этап',
+  linkLabel: 'Стать студентом',
+  paragraph:
+    'Подготовительный этап поможет тем, кто мало знаком или совсем не знаком с программированием и хотел бы впоследствии учиться на основном курсе «JavaScript/Front-end».',
+};
+
 export const introLocalizedContent = {
-  en: {
-    title: 'About the course',
-    linkLabel: 'Become a student',
-    paragraph: '',
-  },
-  ru: {
-    title: 'О курсе',
-    linkLabel: 'Cтать студентом',
-    paragraph: '',
-  },
-  'Pre-school RU': {
-    title: 'JS/Frontend-разработка. Подготовительный этап',
-    linkLabel: 'Стать студентом',
-    paragraph:
-      'Подготовительный этап поможет тем, кто мало знаком или совсем не знаком с программированием и хотел бы впоследствии учиться на основном курсе «JavaScript/Front-end».',
-  },
+  [COURSE_TITLES.JS_PRESCHOOL_RU]: preSchoolIntro,
+  [COURSE_TITLES.JS_EN]: enIntro,
+  [COURSE_TITLES.JS_RU]: ruIntro,
+  [COURSE_TITLES.REACT]: enIntro,
+  [COURSE_TITLES.ANGULAR]: enIntro,
+  [COURSE_TITLES.NODE]: enIntro,
+  [COURSE_TITLES.AWS_FUNDAMENTALS]: enIntro,
+  [COURSE_TITLES.AWS_CLOUD_DEVELOPER]: enIntro,
+  [COURSE_TITLES.AWS_DEVOPS]: enIntro,
 };
 
 const listData = {
@@ -217,8 +227,7 @@ const reactEn: AboutCourseInfo[] = javaScriptEN().map((item) => {
       ...item,
       info: (
         <p>
-          Throughout the course, we mostly use
-          {' '}
+          Throughout the course, we mostly use{' '}
           <LinkCustom href={DISCORD_LINKS[COURSE_TITLES.REACT]} external>
             Discord chat
           </LinkCustom>

--- a/dev-data/about-course.data.tsx
+++ b/dev-data/about-course.data.tsx
@@ -25,7 +25,7 @@ export const introLocalizedContent = {
     linkLabel: 'Cтать студентом',
     paragraph: '',
   },
-  'pre-school-ru': {
+  'Pre-school RU': {
     title: 'JS/Frontend-разработка. Подготовительный этап',
     linkLabel: 'Стать студентом',
     paragraph:

--- a/dev-data/about-course.data.tsx
+++ b/dev-data/about-course.data.tsx
@@ -227,7 +227,8 @@ const reactEn: AboutCourseInfo[] = javaScriptEN().map((item) => {
       ...item,
       info: (
         <p>
-          Throughout the course, we mostly use{' '}
+          Throughout the course, we mostly use
+          {' '}
           <LinkCustom href={DISCORD_LINKS[COURSE_TITLES.REACT]} external>
             Discord chat
           </LinkCustom>

--- a/dev-data/courses.data.ts
+++ b/dev-data/courses.data.ts
@@ -24,6 +24,7 @@ export const courses: Course[] = [
   {
     id: '1',
     title: COURSE_TITLES.JS_PRESCHOOL_RU,
+    subTitle: 'Pre-school RU',
     alias: COURSE_ALIASES.JS_PRESCHOOL_RU,
     altTitle: 'JavaScript / Front-end',
     iconSrc: javascript,
@@ -43,6 +44,7 @@ export const courses: Course[] = [
   {
     id: '2',
     title: COURSE_TITLES.JS_EN,
+    subTitle: null,
     alias: COURSE_ALIASES.JS_EN,
     altTitle: 'JavaScript / Front-end',
     iconSrc: javascript,
@@ -62,6 +64,7 @@ export const courses: Course[] = [
   {
     id: '3',
     title: COURSE_TITLES.JS_RU,
+    subTitle: null,
     alias: COURSE_ALIASES.JS_RU,
     altTitle: 'JavaScript / Front-end',
     iconSrc: javascript,
@@ -81,6 +84,7 @@ export const courses: Course[] = [
   {
     id: '4',
     title: COURSE_TITLES.REACT,
+    subTitle: null,
     alias: COURSE_ALIASES.REACT,
     iconSrc: react,
     iconSmall: reactSmall,
@@ -99,6 +103,7 @@ export const courses: Course[] = [
   {
     id: '5',
     title: COURSE_TITLES.ANGULAR,
+    subTitle: null,
     alias: COURSE_ALIASES.ANGULAR,
     iconSrc: angular,
     iconSmall: angularSmall,
@@ -117,6 +122,7 @@ export const courses: Course[] = [
   {
     id: '6',
     title: COURSE_TITLES.NODE,
+    subTitle: null,
     alias: COURSE_ALIASES.NODE,
     iconSrc: nodejs,
     iconSmall: nodejsSmall,
@@ -135,6 +141,7 @@ export const courses: Course[] = [
   {
     id: '7',
     title: COURSE_TITLES.AWS_FUNDAMENTALS,
+    subTitle: null,
     alias: COURSE_ALIASES.AWS_FUNDAMENTALS,
     iconSrc: aws,
     iconSmall: awsFundSmall,
@@ -154,6 +161,7 @@ export const courses: Course[] = [
   {
     id: '8',
     title: COURSE_TITLES.AWS_CLOUD_DEVELOPER,
+    subTitle: null,
     alias: COURSE_ALIASES.AWS_CLOUD_DEVELOPER,
     iconSrc: aws,
     iconSmall: awsDevSmall,
@@ -172,6 +180,7 @@ export const courses: Course[] = [
   {
     id: '9',
     title: COURSE_TITLES.AWS_DEVOPS,
+    subTitle: null,
     alias: COURSE_ALIASES.AWS_DEVOPS,
     iconSrc: aws,
     iconSmall: awsDevSmall,

--- a/src/app/courses/javascript-preschool-ru/page.tsx
+++ b/src/app/courses/javascript-preschool-ru/page.tsx
@@ -13,7 +13,5 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function JsPreRoute() {
   const course = await selectCourse(courseName);
 
-  return (
-    <JavaScriptPreSchoolRu lang="ru" type="Pre-school RU" course={course} courseName={courseName} />
-  );
+  return <JavaScriptPreSchoolRu lang="ru" course={course} courseName={courseName} />;
 }

--- a/src/app/courses/javascript-preschool-ru/page.tsx
+++ b/src/app/courses/javascript-preschool-ru/page.tsx
@@ -14,6 +14,6 @@ export default async function JsPreRoute() {
   const course = await selectCourse(courseName);
 
   return (
-    <JavaScriptPreSchoolRu lang="ru" type="pre-school-ru" course={course} courseName={courseName} />
+    <JavaScriptPreSchoolRu lang="ru" type="Pre-school RU" course={course} courseName={courseName} />
   );
 }

--- a/src/entities/course/types.ts
+++ b/src/entities/course/types.ts
@@ -25,6 +25,7 @@ export type ApiCoursesResponse = Readonly<{
 export type Course = {
   id: string;
   title: CourseNamesKeys;
+  subTitle: string | null;
   alias: CourseAliasValues;
   altTitle?: string;
   iconSrc: StaticImageData;

--- a/src/shared/__tests__/constants.ts
+++ b/src/shared/__tests__/constants.ts
@@ -25,6 +25,7 @@ export const mockedCourses: Course[] = [
   {
     id: '1',
     title: COURSE_TITLES.JS_PRESCHOOL_RU,
+    subTitle: 'Pre-school RU',
     alias: COURSE_ALIASES.JS_PRESCHOOL_RU,
     startDate: 'Jun 24, 2024',
     registrationEndDate: 'Jun 24, 2024',
@@ -44,6 +45,7 @@ export const mockedCourses: Course[] = [
   {
     id: '2',
     title: COURSE_TITLES.JS_EN,
+    subTitle: null,
     alias: COURSE_ALIASES.JS_EN,
     startDate: 'Oct, 2024',
     registrationEndDate: 'Jun 24, 2025',
@@ -63,6 +65,7 @@ export const mockedCourses: Course[] = [
   {
     id: '3',
     title: COURSE_TITLES.JS_RU,
+    subTitle: null,
     alias: COURSE_ALIASES.JS_RU,
     startDate: 'Oct, 2024',
     registrationEndDate: 'Jun 24, 2025',
@@ -82,6 +85,7 @@ export const mockedCourses: Course[] = [
   {
     id: '4',
     title: COURSE_TITLES.REACT,
+    subTitle: null,
     alias: COURSE_ALIASES.REACT,
     startDate: 'Jul 1, 2024',
     registrationEndDate: 'Jun 24, 2024',
@@ -101,6 +105,7 @@ export const mockedCourses: Course[] = [
   {
     id: '5',
     title: COURSE_TITLES.ANGULAR,
+    subTitle: null,
     alias: COURSE_ALIASES.ANGULAR,
     startDate: 'Jul 1, 2024',
     registrationEndDate: 'Jun 24, 2025',
@@ -120,6 +125,7 @@ export const mockedCourses: Course[] = [
   {
     id: '6',
     title: COURSE_TITLES.AWS_FUNDAMENTALS,
+    subTitle: null,
     alias: COURSE_ALIASES.AWS_FUNDAMENTALS,
     startDate: 'Jul 1, 2024',
     registrationEndDate: 'Jun 24, 2025',

--- a/src/shared/helpers/getActualData.test.ts
+++ b/src/shared/helpers/getActualData.test.ts
@@ -20,6 +20,7 @@ const coursesMock: Course[] = [
     id: '1',
     title: COURSE_TITLES.REACT,
     alias: COURSE_ALIASES.REACT,
+    subTitle: null,
     altTitle: 'altTitle',
     iconSrc: {
       src: 'icon',
@@ -50,6 +51,7 @@ const coursesMock: Course[] = [
   {
     id: '2',
     title: COURSE_TITLES.REACT,
+    subTitle: null,
     alias: COURSE_ALIASES.REACT,
     altTitle: 'altTitle',
     iconSrc: {
@@ -81,6 +83,7 @@ const coursesMock: Course[] = [
   {
     id: '3',
     title: COURSE_TITLES.REACT,
+    subTitle: null,
     alias: COURSE_ALIASES.REACT,
     altTitle: 'altTitle',
     iconSrc: {

--- a/src/views/javascript-preschool-ru.tsx
+++ b/src/views/javascript-preschool-ru.tsx
@@ -13,7 +13,7 @@ import { CourseNames, preSchoolRu } from 'data';
 type JavaScriptPreSchoolRuProps = {
   course: Course;
   lang: 'ru' | 'en';
-  type?: 'pre-school-ru';
+  type?: 'Pre-school RU';
   courseName: CourseNames['JS_PRESCHOOL_RU'];
 };
 

--- a/src/views/javascript-preschool-ru.tsx
+++ b/src/views/javascript-preschool-ru.tsx
@@ -13,21 +13,15 @@ import { CourseNames, preSchoolRu } from 'data';
 type JavaScriptPreSchoolRuProps = {
   course: Course;
   lang: 'ru' | 'en';
-  type?: 'Pre-school RU';
   courseName: CourseNames['JS_PRESCHOOL_RU'];
 };
 
-export const JavaScriptPreSchoolRu = ({
-  lang,
-  type,
-  course,
-  courseName,
-}: JavaScriptPreSchoolRuProps) => {
+export const JavaScriptPreSchoolRu = ({ lang, course, courseName }: JavaScriptPreSchoolRuProps) => {
   return (
     <>
-      <HeroCourse type={type} lang={lang} course={course} />
+      <HeroCourse lang={lang} course={course} />
       <Breadcrumbs />
-      <AboutCourse courseName={courseName} type={type} course={course} />
+      <AboutCourse courseName={courseName} course={course} />
       <TrainingProgram courseName={courseName} lang={lang} course={course} />
       <Required courseName={courseName} />
       <Certification courseName={courseName} />

--- a/src/views/javascript-ru.tsx
+++ b/src/views/javascript-ru.tsx
@@ -25,7 +25,7 @@ export const JavaScriptRu = ({ lang, course, courseName }: JavaScriptRuProps) =>
       <HeroCourse course={course} lang={lang} />
       <Breadcrumbs />
       <TrainingProgram course={course} courseName={courseName} lang={lang} />
-      <AboutCourse course={course} courseName={courseName} type={lang} />
+      <AboutCourse course={course} courseName={courseName} />
       <Certification courseName={courseName} />
       <Communication courseName={courseName} lang={lang} />
       <AboutVideo lang={lang} />

--- a/src/widgets/about-course/ui/about-course/about-course.test.tsx
+++ b/src/widgets/about-course/ui/about-course/about-course.test.tsx
@@ -79,7 +79,7 @@ describe('AboutCourse component', () => {
         <AboutCourse
           course={mockedPreSchoolCourse}
           courseName="JS / Front-end Pre-school RU"
-          type="pre-school-ru"
+          type="Pre-school RU"
         />,
       );
 

--- a/src/widgets/about-course/ui/about-course/about-course.test.tsx
+++ b/src/widgets/about-course/ui/about-course/about-course.test.tsx
@@ -18,6 +18,7 @@ const mockedReactCourse: Course = {
   iconSmall: MOCKED_IMAGE_PATH,
   iconSrc: MOCKED_IMAGE_PATH,
   title: COURSE_TITLES.REACT,
+  subTitle: null,
   alias: COURSE_ALIASES.REACT,
   language: ['en'],
   mode: 'online',
@@ -76,11 +77,7 @@ describe('AboutCourse component', () => {
   describe('render "Paragraph" with "js / front-end pre-school ru" props', () => {
     it("renders 'Paragraph' and its' content", async () => {
       renderWithRouter(
-        <AboutCourse
-          course={mockedPreSchoolCourse}
-          courseName="JS / Front-end Pre-school RU"
-          type="Pre-school RU"
-        />,
+        <AboutCourse course={mockedPreSchoolCourse} courseName="JS / Front-end Pre-school RU" />,
       );
 
       const paragraph = await screen.findByText(/Подготовительный этап поможет тем/i);

--- a/src/widgets/about-course/ui/about-course/about-course.tsx
+++ b/src/widgets/about-course/ui/about-course/about-course.tsx
@@ -12,7 +12,7 @@ export const cx = classNames.bind(styles);
 
 type AboutCourseProps = {
   courseName: CourseNamesKeys;
-  type?: 'ru' | 'en' | 'pre-school-ru';
+  type?: 'ru' | 'en' | 'Pre-school RU';
   course: Course;
 };
 

--- a/src/widgets/about-course/ui/about-course/about-course.tsx
+++ b/src/widgets/about-course/ui/about-course/about-course.tsx
@@ -12,23 +12,22 @@ export const cx = classNames.bind(styles);
 
 type AboutCourseProps = {
   courseName: CourseNamesKeys;
-  type?: 'ru' | 'en' | 'Pre-school RU';
   course: Course;
 };
 
-export const AboutCourse = ({ course, courseName, type = 'en' }: AboutCourseProps) => {
+export const AboutCourse = ({ course, courseName }: AboutCourseProps) => {
   const courseInfoList = contentMapAbout[courseName];
 
   return (
     <section className={cx('container')}>
       <div className={cx('about-course', 'content')}>
-        <WidgetTitle>{introLocalizedContent[type].title}</WidgetTitle>
-        {introLocalizedContent[type]?.paragraph && (
-          <Paragraph>{introLocalizedContent[type].paragraph}</Paragraph>
+        <WidgetTitle>{introLocalizedContent[courseName].title}</WidgetTitle>
+        {introLocalizedContent[courseName]?.paragraph && (
+          <Paragraph>{introLocalizedContent[courseName].paragraph}</Paragraph>
         )}
         <AboutCourseGrid items={courseInfoList} />
         <LinkCustom href={course.enroll} variant="primary" external>
-          {introLocalizedContent[type]?.linkLabel}
+          {introLocalizedContent[courseName]?.linkLabel}
         </LinkCustom>
       </div>
     </section>

--- a/src/widgets/hero-course/ui/hero-course.test.tsx
+++ b/src/widgets/hero-course/ui/hero-course.test.tsx
@@ -29,35 +29,48 @@ const mockedCourse: Course = {
 };
 
 describe('HeroCourse component', () => {
-  beforeEach(() => {
-    renderWithRouter(<HeroCourse course={mockedCourse} />);
+  describe('Render general content', () => {
+    beforeEach(() => {
+      renderWithRouter(<HeroCourse course={mockedCourse} />);
+    });
+
+    it('renders the title and label correctly', async () => {
+      const titleElement = await screen.findByText('Node.js Course');
+      const labelElement = screen.getByText('planned');
+
+      expect(titleElement).toBeVisible();
+      expect(labelElement).toBeVisible();
+    });
+
+    it('renders enroll button with correct label and href', () => {
+      const buttonElement = screen.getByRole('link', { name: /enroll/i });
+
+      expect(buttonElement).toBeVisible();
+      expect(buttonElement).toHaveAttribute('href', 'https://test.com');
+    });
+
+    it('renders the image with correct source', () => {
+      const imageElement = screen.getByRole('img', { name: /Node.js/i });
+
+      expect(imageElement).toBeInTheDocument();
+      expect(imageElement).toHaveAttribute('src', MOCKED_IMAGE_PATH.src);
+    });
   });
 
-  it('renders the title and label correctly', async () => {
-    const titleElement = await screen.findByText('Node.js Course');
-    const labelElement = screen.getByText('planned');
+  describe('Render subtitle', () => {
+    it('renders the subtitle when provided', async () => {
+      renderWithRouter(<HeroCourse course={mockedCourse} />);
+      const subtitleElement = await screen.findByText('Test Subtitle');
 
-    expect(titleElement).toBeVisible();
-    expect(labelElement).toBeVisible();
-  });
+      expect(subtitleElement).toBeVisible();
+    });
 
-  it('renders enroll button with correct label and href', () => {
-    const buttonElement = screen.getByRole('link', { name: /enroll/i });
+    it('does not display subtitles if they are not provided', () => {
+      mockedCourse.subTitle = null;
+      renderWithRouter(<HeroCourse course={mockedCourse} />);
+      const subtitleElement = screen.queryByText('Test Subtitle');
 
-    expect(buttonElement).toBeVisible();
-    expect(buttonElement).toHaveAttribute('href', 'https://test.com');
-  });
-
-  it('renders the image with correct source', () => {
-    const imageElement = screen.getByRole('img', { name: /Node.js/i });
-
-    expect(imageElement).toBeInTheDocument();
-    expect(imageElement).toHaveAttribute('src', MOCKED_IMAGE_PATH.src);
-  });
-
-  it('renders the subtitle when provided', async () => {
-    const subtitleElement = await screen.findByText('Test Subtitle');
-
-    expect(subtitleElement).toBeVisible();
+      expect(subtitleElement).toBeNull();
+    });
   });
 });

--- a/src/widgets/hero-course/ui/hero-course.test.tsx
+++ b/src/widgets/hero-course/ui/hero-course.test.tsx
@@ -11,7 +11,7 @@ import { COURSE_TITLES } from 'data';
 const mockedCourse: Course = {
   id: '6',
   title: COURSE_TITLES.NODE,
-  subTitle: null,
+  subTitle: 'Test Subtitle',
   alias: COURSE_ALIASES.NODE,
   iconSrc: MOCKED_IMAGE_PATH,
   iconSmall: MOCKED_IMAGE_PATH,
@@ -53,5 +53,11 @@ describe('HeroCourse component', () => {
 
     expect(imageElement).toBeInTheDocument();
     expect(imageElement).toHaveAttribute('src', MOCKED_IMAGE_PATH.src);
+  });
+
+  it('renders the subtitle when provided', async () => {
+    const subtitleElement = await screen.findByText('Test Subtitle');
+
+    expect(subtitleElement).toBeVisible();
   });
 });

--- a/src/widgets/hero-course/ui/hero-course.test.tsx
+++ b/src/widgets/hero-course/ui/hero-course.test.tsx
@@ -27,6 +27,25 @@ const mockedCourse: Course = {
     accentColor: '#AEDF36',
   },
 };
+const mockedCourseNoSubtitle: Course = {
+  id: '6',
+  title: COURSE_TITLES.NODE,
+  subTitle: null,
+  alias: COURSE_ALIASES.NODE,
+  iconSrc: MOCKED_IMAGE_PATH,
+  iconSmall: MOCKED_IMAGE_PATH,
+  secondaryIcon: MOCKED_IMAGE_PATH,
+  startDate: dayJS().subtract(2, 'month').format('D MMM, YYYY'),
+  registrationEndDate: TO_BE_DETERMINED,
+  language: ['en'],
+  mode: 'online',
+  detailsUrl: `/${ROUTES.COURSES}/${ROUTES.NODE_JS}`,
+  enroll: 'https://test.com',
+  backgroundStyle: {
+    backgroundColor: '#F0F9F4',
+    accentColor: '#AEDF36',
+  },
+};
 
 describe('HeroCourse component', () => {
   describe('Render general content', () => {
@@ -34,12 +53,14 @@ describe('HeroCourse component', () => {
       renderWithRouter(<HeroCourse course={mockedCourse} />);
     });
 
-    it('renders the title and label correctly', async () => {
+    it('renders the title, label and subtitle correctly', async () => {
       const titleElement = await screen.findByText('Node.js Course');
       const labelElement = screen.getByText('planned');
+      const subtitleElement = await screen.findByText('Test Subtitle');
 
       expect(titleElement).toBeVisible();
       expect(labelElement).toBeVisible();
+      expect(subtitleElement).toBeVisible();
     });
 
     it('renders enroll button with correct label and href', () => {
@@ -57,17 +78,9 @@ describe('HeroCourse component', () => {
     });
   });
 
-  describe('Render subtitle', () => {
-    it('renders the subtitle when provided', async () => {
-      renderWithRouter(<HeroCourse course={mockedCourse} />);
-      const subtitleElement = await screen.findByText('Test Subtitle');
-
-      expect(subtitleElement).toBeVisible();
-    });
-
+  describe('Render widget with empty subtitle', () => {
     it('does not display subtitles if they are not provided', () => {
-      mockedCourse.subTitle = null;
-      renderWithRouter(<HeroCourse course={mockedCourse} />);
+      renderWithRouter(<HeroCourse course={mockedCourseNoSubtitle} />);
       const subtitleElement = screen.queryByText('Test Subtitle');
 
       expect(subtitleElement).toBeNull();

--- a/src/widgets/hero-course/ui/hero-course.test.tsx
+++ b/src/widgets/hero-course/ui/hero-course.test.tsx
@@ -11,6 +11,7 @@ import { COURSE_TITLES } from 'data';
 const mockedCourse: Course = {
   id: '6',
   title: COURSE_TITLES.NODE,
+  subTitle: null,
   alias: COURSE_ALIASES.NODE,
   iconSrc: MOCKED_IMAGE_PATH,
   iconSmall: MOCKED_IMAGE_PATH,

--- a/src/widgets/hero-course/ui/hero-course.tsx
+++ b/src/widgets/hero-course/ui/hero-course.tsx
@@ -16,12 +16,20 @@ const cx = classNames.bind(styles);
 type HeroCourseProps = {
   course: Course;
   lang?: 'ru' | 'en';
-  type?: 'Pre-school RU';
 };
 
-export const HeroCourse = ({ lang = 'en', type, course }: HeroCourseProps) => {
-  const { title, altTitle, language, mode, enroll, secondaryIcon, startDate, registrationEndDate } =
-    course;
+export const HeroCourse = ({ lang = 'en', course }: HeroCourseProps) => {
+  const {
+    title,
+    subTitle,
+    altTitle,
+    language,
+    mode,
+    enroll,
+    secondaryIcon,
+    startDate,
+    registrationEndDate,
+  } = course;
   const status = getCourseStatus(startDate, dayJS(registrationEndDate).diff(startDate, 'd'));
 
   return (
@@ -31,7 +39,7 @@ export const HeroCourse = ({ lang = 'en', type, course }: HeroCourseProps) => {
         <article>
           <SectionLabel data-testid="course-label">{status}</SectionLabel>
           <MainTitle size="small">{`${altTitle || title} Course`}</MainTitle>
-          {type && <p className={cx('hero-subtitle')}>{type}</p>}
+          {subTitle && <p className={cx('hero-subtitle')}>{subTitle}</p>}
           <DateLang
             startDate={startDate}
             registrationEndDate={registrationEndDate}

--- a/src/widgets/hero-course/ui/hero-course.tsx
+++ b/src/widgets/hero-course/ui/hero-course.tsx
@@ -16,7 +16,7 @@ const cx = classNames.bind(styles);
 type HeroCourseProps = {
   course: Course;
   lang?: 'ru' | 'en';
-  type?: 'pre-school-ru';
+  type?: 'Pre-school RU';
 };
 
 export const HeroCourse = ({ lang = 'en', type, course }: HeroCourseProps) => {

--- a/src/widgets/training-program/ui/training-program.test.tsx
+++ b/src/widgets/training-program/ui/training-program.test.tsx
@@ -11,6 +11,7 @@ import { COURSE_TITLES } from 'data';
 const mockedCourseAngular: Course = {
   id: '1',
   title: COURSE_TITLES.ANGULAR,
+  subTitle: null,
   alias: COURSE_ALIASES.ANGULAR,
   startDate: '16 Oct, 2023',
   registrationEndDate: '16 Oct, 2024',
@@ -37,6 +38,7 @@ const mockedCourseAws: Course = {
   startDate: '',
   registrationEndDate: TO_BE_DETERMINED,
   title: COURSE_TITLES.AWS_CLOUD_DEVELOPER,
+  subTitle: null,
   alias: COURSE_ALIASES.AWS_CLOUD_DEVELOPER,
   detailsUrl: `/${ROUTES.COURSES}/${ROUTES.AWS_DEVELOPER}`,
   enroll: 'https://wearecommunity.io/events/aws-cloud-dev-rs2023q4',


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description
fix subtitle in hero widget pre-school cource

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #614 

## Screenshots, Recordings

_Please replace this line with any relevant images for UI changes._

## Added/updated tests?

- [x] 👌 Yes
- [ ] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced localized introductory content for courses in English and Russian.
	- Added a `subTitle` property to course objects, enhancing course detail visibility.

- **Improvements**
	- Simplified component props by removing unnecessary `type` properties, focusing on `courseName` for localized content retrieval.
	- Enhanced the rendering logic to display subtitles where available, improving content presentation.

These updates streamline user experience and improve content accessibility across the platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->