### PR TITLE
fix: 642 - empty upcoming courses

### DIFF
--- a/src/widgets/upcoming-courses/ui/upcoming-courses.tsx
+++ b/src/widgets/upcoming-courses/ui/upcoming-courses.tsx
@@ -38,24 +38,28 @@ export const UpcomingCourses = async () => {
     });
 
   return (
-    <article id="upcoming-courses" className={cx('container')}>
-      <section className={cx('content')}>
-        <WidgetTitle size="small">Upcoming courses</WidgetTitle>
-        <div className={cx('column-2')}>
-          <div className={cx('course-list')} data-testid="courses-list">
-            {coursesContent}
-            <LinkCustom href={ROUTES.COURSES} variant="primary">
-              Go to courses
-            </LinkCustom>
-          </div>
-          <Image
-            className={cx('rs-banner')}
-            data-testid="rs-banner"
-            src={RSBanner}
-            alt="The Rolling Scopes organization logo"
-          />
-        </div>
-      </section>
-    </article>
+    <>
+      {coursesContent.length > 0 && (
+        <article id="upcoming-courses" className={cx('container')}>
+          <section className={cx('content')}>
+            <WidgetTitle size="small">Upcoming courses</WidgetTitle>
+            <div className={cx('column-2')}>
+              <div className={cx('course-list')} data-testid="courses-list">
+                {coursesContent}
+                <LinkCustom href={ROUTES.COURSES} variant="primary">
+                  Go to courses
+                </LinkCustom>
+              </div>
+              <Image
+                className={cx('rs-banner')}
+                data-testid="rs-banner"
+                src={RSBanner}
+                alt="The Rolling Scopes organization logo"
+              />
+            </div>
+          </section>
+        </article>
+      )}
+    </>
   );
 };


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description
show widget if upcoming courses array is not empty

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #642 

## Screenshots, Recordings

_Please replace this line with any relevant images for UI changes._

## Added/updated tests?

- [ ] 👌 Yes
- [x] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
