### PR TITLE
738-fix: Logo shrinking on small screens

### DIFF
--- a/src/core/base-layout/components/header/burger/burger.module.scss
+++ b/src/core/base-layout/components/header/burger/burger.module.scss
@@ -54,10 +54,6 @@
     .bottom {
       transform: rotate(45deg) translate(-5px, -6px);
     }
-
-    @include media-tablet-large {
-      display: block;
-    }
   }
 
   @include media-hover {

--- a/src/core/base-layout/components/header/burger/burger.module.scss
+++ b/src/core/base-layout/components/header/burger/burger.module.scss
@@ -55,7 +55,7 @@
       transform: rotate(45deg) translate(-5px, -6px);
     }
 
-    @include media-tablet {
+    @include media-tablet-large {
       display: block;
     }
   }
@@ -70,7 +70,7 @@
     }
   }
 
-  @include media-tablet {
+  @include media-tablet-large {
     z-index: 10;
     display: block;
   }

--- a/src/core/base-layout/components/header/header.module.scss
+++ b/src/core/base-layout/components/header/header.module.scss
@@ -32,7 +32,7 @@
     box-shadow: rgb(0 0 0 / 8.2%) 0 1.026px 8.0694px 0;
   }
 
-  @include media-tablet {
+  @include media-tablet-large {
     height: 48px;
     padding: 0 16px;
   }
@@ -57,7 +57,7 @@
 
   height: 100%;
 
-  @include media-tablet {
+  @include media-tablet-large {
     display: none;
   }
 }
@@ -108,7 +108,7 @@
   transform: translateY(0);
   display: none;
 
-  @include media-tablet {
+  @include media-tablet-large {
     display: block;
   }
 }

--- a/src/shared/ui/logo/logo.module.scss
+++ b/src/shared/ui/logo/logo.module.scss
@@ -1,16 +1,16 @@
 .logo {
-  width: 100%;
-  max-width: 56px;
-  max-height: 56px;
+  flex-shrink: 0;
+  width: 56px;
+  height: 56px;
 
   img {
     width: 100%;
     height: 100%;
   }
 
-  @include media-tablet {
-    max-width: 40px;
-    max-height: 40px;
+  @include media-tablet-large {
+    width: 40px;
+    height: 40px;
   }
 }
 

--- a/src/widgets/mobile-view/ui/mobile-view.module.scss
+++ b/src/widgets/mobile-view/ui/mobile-view.module.scss
@@ -8,7 +8,7 @@
 
   width: 100%;
 
-  @include media-tablet {
+  @include media-tablet-large {
     display: flex;
   }
 }


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description
Fixed:
1. Logo sizing (56px x 56px and 40px x 40px for media-tablet-large)
2. Breakpoints for menu burgering (from media-tablet to media-tablet-large)

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #738
- Closes #738

## Screenshots, Recordings

https://github.com/user-attachments/assets/d2687d74-c149-4647-8bf9-18b64e8b14fe

## Added/updated tests?

- [ ] 👌 Yes
- [ ] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated media query mixins in multiple components to use `media-tablet-large` instead of `media-tablet`
	- Adjusted logo styling with fixed dimensions and added `flex-shrink` property
	- Modified responsive design breakpoints for header, burger menu, and mobile view components
<!-- end of auto-generated comment: release notes by coderabbit.ai -->