### PR TITLE
761-fix: Filter out private videos on mentorship page

### DIFF
--- a/src/shared/ui/video-playlist-with-player/constants.ts
+++ b/src/shared/ui/video-playlist-with-player/constants.ts
@@ -1,0 +1,4 @@
+export const videoPrivacyStatus = {
+  private: 'private',
+  public: 'public',
+} as const;

--- a/src/shared/ui/video-playlist-with-player/video-playlist-with-player.test.tsx
+++ b/src/shared/ui/video-playlist-with-player/video-playlist-with-player.test.tsx
@@ -41,6 +41,7 @@ describe('VideoPlaylistWithPlayer Component', () => {
             title: video.title,
             thumbnails: { medium: { url: video.thumbnail } },
           },
+          status: { privacyStatus: 'public' },
         })),
       }),
     } as Response);
@@ -65,6 +66,7 @@ describe('VideoPlaylistWithPlayer Component', () => {
             title: video.title,
             thumbnails: { medium: { url: video.thumbnail } },
           },
+          status: { privacyStatus: 'public' },
         })),
       }),
     } as Response);
@@ -112,6 +114,7 @@ describe('VideoPlaylistWithPlayer Component', () => {
             title: video.title,
             thumbnails: { medium: { url: video.thumbnail } },
           },
+          status: { privacyStatus: 'public' },
         })),
       }),
     } as Response);
@@ -140,5 +143,39 @@ describe('VideoPlaylistWithPlayer Component', () => {
     await waitFor(() => {
       expect(playlistContainer).toHaveStyle({ maxHeight: '300px' });
     });
+  });
+
+  it('should filter out private videos', async () => {
+    const publicVideos = MOCKED_VIDEOS.map((video) => ({
+      snippet: {
+        resourceId: { videoId: video.id },
+        title: video.title,
+        thumbnails: { medium: { url: video.thumbnail } },
+      },
+      status: { privacyStatus: 'public' },
+    }));
+    const privateVideos = MOCKED_VIDEOS.map((video) => ({
+      snippet: {
+        resourceId: { videoId: video.id },
+        title: video.title,
+        thumbnails: { medium: { url: video.thumbnail } },
+      },
+      status: { privacyStatus: 'private' },
+    }));
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [...publicVideos, ...privateVideos] }),
+    } as Response);
+
+    render(<VideoPlaylistWithPlayer playlistId="testPlaylist" apiKey="testApiKey" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('videos-container')).toBeVisible();
+    });
+
+    const videosContainer = screen.getByTestId('videos-container');
+
+    expect(videosContainer.children).toHaveLength(3);
   });
 });

--- a/src/shared/ui/video-playlist-with-player/video-playlist-with-player.tsx
+++ b/src/shared/ui/video-playlist-with-player/video-playlist-with-player.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import classNames from 'classnames/bind';
 
+import { videoPrivacyStatus } from './constants';
 import { Playlist } from './playlist';
 import type { Video } from '@/shared/types';
 import { VideoPlayer } from '@/shared/ui/video-player';
@@ -29,7 +30,7 @@ export const VideoPlaylistWithPlayer = ({ playlistId, apiKey }: VideoPlaylistWit
       setIsLoading(true);
 
       try {
-        const apiUrl = `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=50&playlistId=${playlistId}&key=${apiKey}`;
+        const apiUrl = `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet,status&maxResults=50&playlistId=${playlistId}&key=${apiKey}`;
         const response = await fetch(apiUrl);
 
         if (!response.ok) {
@@ -39,7 +40,12 @@ export const VideoPlaylistWithPlayer = ({ playlistId, apiKey }: VideoPlaylistWit
         }
 
         const data = await response.json();
-        const videoItems: Video[] = data.items.map(
+        const publicVideos = data.items.filter(
+          (item: GoogleApiYouTubePlaylistItemResource) =>
+            item.status.privacyStatus === videoPrivacyStatus.public,
+        );
+
+        const videoItems: Video[] = publicVideos.map(
           (item: GoogleApiYouTubePlaylistItemResource) => ({
             id: item.snippet.resourceId.videoId,
             title: item.snippet.title,


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #761 
- Closes #761 

## Screenshots, Recordings

_Please replace this line with any relevant images for UI changes._

## Added/updated tests?

- [x] 👌 Yes
- [ ] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
