### PR TITLE
DRAFT 742-feat: Update subtitle to support heading tags

### DIFF
--- a/src/app/docs/components/search/search.tsx
+++ b/src/app/docs/components/search/search.tsx
@@ -137,7 +137,7 @@ function Result({ result }: { result: PagefindSearchResult }) {
           {data.sub_results.map((subresult, index) => (
             <div key={index} className={cx('subresult')}>
               <Link href={removeHtmlExtension(subresult.url)}>
-                <h4>{subresult.title}</h4>
+                <Subtitle>{subresult.title}</Subtitle>
                 <p dangerouslySetInnerHTML={{ __html: subresult.excerpt }} />
               </Link>
             </div>

--- a/src/app/docs/components/search/search.tsx
+++ b/src/app/docs/components/search/search.tsx
@@ -7,6 +7,7 @@ import { createPortal } from 'react-dom';
 
 import MOCKED_SEARCH from '../../mocked_search';
 import { Language } from '@/shared/types';
+import { Subtitle } from '@/shared/ui/subtitle';
 
 import styles from './search.module.scss';
 
@@ -127,7 +128,7 @@ function Result({ result }: { result: PagefindSearchResult }) {
   return (
     <div>
       <Link href={removeHtmlExtension(data.url)}>
-        <h3>{data.meta.title}</h3>
+        <Subtitle>{data.meta.title}</Subtitle>
         <p dangerouslySetInnerHTML={{ __html: data.excerpt }} />
       </Link>
 

--- a/src/app/docs/components/search/search.tsx
+++ b/src/app/docs/components/search/search.tsx
@@ -137,7 +137,7 @@ function Result({ result }: { result: PagefindSearchResult }) {
           {data.sub_results.map((subresult, index) => (
             <div key={index} className={cx('subresult')}>
               <Link href={removeHtmlExtension(subresult.url)}>
-                <Subtitle>{subresult.title}</Subtitle>
+                <Subtitle as="h4">{subresult.title}</Subtitle>
                 <p dangerouslySetInnerHTML={{ __html: subresult.excerpt }} />
               </Link>
             </div>

--- a/src/entities/event/ui/event-card/event-card.module.scss
+++ b/src/entities/event/ui/event-card/event-card.module.scss
@@ -47,13 +47,11 @@
 
       .organized-by {
         margin-bottom: 0;
-        font-weight: $font-weight-regular;
       }
 
       .event-organization {
         margin-top: 10px;
         font-size: 20px;
-        font-weight: $font-weight-medium;
       }
     }
 
@@ -66,7 +64,6 @@
       .event-title {
         margin-top: 16px;
         margin-bottom: 0;
-        font-weight: $font-weight-medium;
         line-height: 32px;
 
         @include media-mobile {

--- a/src/entities/event/ui/event-card/event-card.tsx
+++ b/src/entities/event/ui/event-card/event-card.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames/bind';
 
 import { Event } from '@/entities/event';
 import { LinkCustom } from '@/shared/ui/link-custom';
+import { Subtitle } from '@/shared/ui/subtitle';
 
 import styles from './event-card.module.scss';
 
@@ -30,12 +31,20 @@ export const EventCard = ({
       <div className={cx('card-header')} data-testid="card-header">
         <p className={cx('event-tag')}>{eventType}</p>
         <section className={cx('about-organization')} data-testid="organization-section">
-          <h4 className={cx('organized-by')}>{organizedBy}</h4>
-          <h3 className={cx('event-organization')}>{organization}</h3>
+          <Subtitle as="h4" weight="regular" className={cx('organized-by')}>
+            {organizedBy}
+          </Subtitle>
+          <Subtitle as="h3" weight="normal" className={cx('event-organization')}>
+            {organization}
+          </Subtitle>
         </section>
         <section className={cx('about-event')} data-testid="about-section">
-          <h2 className={cx('event-title')}>{title}</h2>
-          <p title={additionalInfo} className={cx('event-additional-info')}>{additionalInfo}</p>
+          <Subtitle as="h2" weight="normal" className={cx('event-title')}>
+            {title}
+          </Subtitle>
+          <p title={additionalInfo} className={cx('event-additional-info')}>
+            {additionalInfo}
+          </p>
         </section>
       </div>
 

--- a/src/entities/event/ui/event-card/event-card.tsx
+++ b/src/entities/event/ui/event-card/event-card.tsx
@@ -34,7 +34,7 @@ export const EventCard = ({
           <Subtitle as="h4" weight="regular" className={cx('organized-by')}>
             {organizedBy}
           </Subtitle>
-          <Subtitle as="h3" weight="normal" className={cx('event-organization')}>
+          <Subtitle weight="normal" className={cx('event-organization')}>
             {organization}
           </Subtitle>
         </section>

--- a/src/entities/mentor/ui/mentor-feedback-card/mentor-feedback-card.module.scss
+++ b/src/entities/mentor/ui/mentor-feedback-card/mentor-feedback-card.module.scss
@@ -45,14 +45,9 @@
   flex-direction: column;
   gap: 18px;
 
-  .card-title {
-    font-weight: $font-weight-bold;
-  }
-
   .card-subtitle {
     margin: 0;
     font-size: 18px;
-    font-weight: $font-weight-medium;
   }
 }
 

--- a/src/entities/mentor/ui/mentor-feedback-card/mentor-feedback-card.tsx
+++ b/src/entities/mentor/ui/mentor-feedback-card/mentor-feedback-card.tsx
@@ -39,13 +39,18 @@ export const MentorFeedbackCard = ({ name, course, review, photo }: MentorFeedba
           data-testid="mentor-photo"
         />
         <header className={cx('card-header')}>
-          <Subtitle fontSize="small" className={cx('card-title')} data-testid="card-title">
+          <Subtitle fontSize="small" weight="bold" data-testid="card-title">
             {name}
           </Subtitle>
-          <h4 className={cx('card-subtitle')} data-testid="card-subtitle">
+          <Subtitle
+            as="h4"
+            weight="normal"
+            className={cx('card-subtitle')}
+            data-testid="card-subtitle"
+          >
             <b>Course: </b>
             {course}
-          </h4>
+          </Subtitle>
         </header>
       </section>
       <div className={cx('card-content-wrapper')} data-testid="card-content-wrapper">

--- a/src/entities/trainer/ui/trainers-card/trainer-card.module.scss
+++ b/src/entities/trainer/ui/trainers-card/trainer-card.module.scss
@@ -28,7 +28,6 @@
   .card-title {
     margin: 0;
     font-size: 24px;
-    font-weight: $font-weight-medium;
     line-height: 32px;
 
     @include media-tablet {
@@ -39,7 +38,6 @@
   .card-subtitle {
     margin: 0;
     font-size: 18px;
-    font-weight: $font-weight-medium;
     color: $color-gray-500;
 
     @include media-tablet {

--- a/src/entities/trainer/ui/trainers-card/trainer-card.tsx
+++ b/src/entities/trainer/ui/trainers-card/trainer-card.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames/bind';
 import Image from 'next/image';
 
 import { Trainer } from '../../types';
+import { Subtitle } from '@/shared/ui/subtitle';
 
 import styles from './trainer-card.module.scss';
 
@@ -15,8 +16,8 @@ export const TrainerCard = ({ name, bio, role, photo }: Trainer) => {
       </div>
       <div className={cx('card-text')}>
         <header>
-          <h3 className={cx('card-title')}>{name}</h3>
-          <h4 className={cx('card-subtitle')}>{role}</h4>
+          <Subtitle weight="normal" className={cx('card-title')}>{name}</Subtitle>
+          <Subtitle as="h4" weight="normal" className={cx('card-subtitle')}>{role}</Subtitle>
         </header>
         <p className={cx('card-content')}>{bio}</p>
       </div>

--- a/src/shared/ui/modal/modal.tsx
+++ b/src/shared/ui/modal/modal.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { createPortal } from 'react-dom';
 
 import closeIcon from '@/shared/assets/svg/close.svg';
+import { Subtitle } from '@/shared/ui/subtitle';
 
 import styles from './modal.module.scss';
 
@@ -76,9 +77,9 @@ export const Modal = ({ isOpen, onClose, children, title, className }: ModalProp
     >
       <div className={cx('modal-header', { 'no-title': !title })} data-testid="modal-header">
         {title && (
-          <h2 className={cx('modal-title')} data-testid="modal-title">
+          <Subtitle as="h2" className={cx('modal-title')} data-testid="modal-title">
             {title}
-          </h2>
+          </Subtitle>
         )}
         <button
           className={cx('modal-close-button')}

--- a/src/shared/ui/subtitle/subtitle.module.scss
+++ b/src/shared/ui/subtitle/subtitle.module.scss
@@ -52,6 +52,14 @@
     }
   }
 
+  &.light {
+    font-weight: $font-weight-light;
+  }
+
+  &.regular {
+    font-weight: $font-weight-regular;
+  }
+
   &.normal {
     font-weight: $font-weight-medium;
   }

--- a/src/shared/ui/subtitle/subtitle.test.tsx
+++ b/src/shared/ui/subtitle/subtitle.test.tsx
@@ -63,10 +63,38 @@ describe('Subtitle component', () => {
     expect(subtitle).toHaveClass('custom-class');
   });
 
-  it('renders as h3 element', () => {
+  it('renders as h3 element by default', () => {
     render(<Subtitle>H3 Element</Subtitle>);
     const subtitle = screen.getByTestId('subtitle');
 
     expect(subtitle.tagName).toBe('H3');
+  });
+
+  it('renders as h2 element', () => {
+    render(<Subtitle as="h2">H2 Element</Subtitle>);
+    const subtitle = screen.getByTestId('subtitle');
+
+    expect(subtitle.tagName).toBe('H2');
+  });
+
+  it('renders as h4 element', () => {
+    render(<Subtitle as="h4">H4 Element</Subtitle>);
+    const subtitle = screen.getByTestId('subtitle');
+
+    expect(subtitle.tagName).toBe('H4');
+  });
+
+  it('renders as h5 element', () => {
+    render(<Subtitle as="h5">H5 Element</Subtitle>);
+    const subtitle = screen.getByTestId('subtitle');
+
+    expect(subtitle.tagName).toBe('H5');
+  });
+
+  it('renders as h6 element', () => {
+    render(<Subtitle as="h6">H6 Element</Subtitle>);
+    const subtitle = screen.getByTestId('subtitle');
+
+    expect(subtitle.tagName).toBe('H6');
   });
 });

--- a/src/shared/ui/subtitle/subtitle.tsx
+++ b/src/shared/ui/subtitle/subtitle.tsx
@@ -21,6 +21,8 @@ const subtitleVariants = cva(cx('subtitle'), {
       'extra-large': cx('extra-large-font-size'),
     },
     weight: {
+      light: cx('light'),
+      regular: cx('regular'),
       normal: cx('normal'),
       bold: cx('bold'),
     },

--- a/src/shared/ui/subtitle/subtitle.tsx
+++ b/src/shared/ui/subtitle/subtitle.tsx
@@ -5,7 +5,9 @@ import classNames from 'classnames/bind';
 import styles from './subtitle.module.scss';
 
 type SubtitleProps = Pick<HTMLAttributes<HTMLHeadingElement>, 'className' | 'children'> &
-  VariantProps<typeof subtitleVariants>;
+  VariantProps<typeof subtitleVariants> & {
+    as?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  };
 
 export const cx = classNames.bind(styles);
 
@@ -29,9 +31,18 @@ const subtitleVariants = cva(cx('subtitle'), {
   },
 });
 
-export const Subtitle = ({ children, fontSize, weight, className, ...props }: SubtitleProps) => {
+export const Subtitle = ({
+  as = 'h3',
+  children,
+  fontSize,
+  weight,
+  className,
+  ...props
+}: SubtitleProps) => {
+  const HeadingTag = as;
+
   return (
-    <h3
+    <HeadingTag
       className={subtitleVariants({
         fontSize,
         weight,
@@ -41,6 +52,6 @@ export const Subtitle = ({ children, fontSize, weight, className, ...props }: Su
       {...props}
     >
       {children}
-    </h3>
+    </HeadingTag>
   );
 };

--- a/src/shared/ui/video-playlist-with-player/playlist/playlist.tsx
+++ b/src/shared/ui/video-playlist-with-player/playlist/playlist.tsx
@@ -2,6 +2,7 @@ import React, { CSSProperties } from 'react';
 import classNames from 'classnames/bind';
 
 import type { Video } from '@/shared/types';
+import { Subtitle } from '@/shared/ui/subtitle';
 
 import styles from './playlist.module.scss';
 
@@ -20,7 +21,7 @@ export const Playlist = ({ title, videos, onSelectVideo, selectedVideoId, style 
 
   return (
     <div className={cx('playlist')} style={style} data-testid="playlist">
-      <h3 className={cx('playlist-title')} data-testid="playlist-title">{`${videos.length} ${title}`}</h3>
+      <Subtitle className={cx('playlist-title')} data-testid="playlist-title">{`${videos.length} ${title}`}</Subtitle>
       <div className={cx('videos-container')} data-testid="videos-container">
         {videos.map((video) => (
           <div

--- a/src/shared/ui/widget-title/widget-title.tsx
+++ b/src/shared/ui/widget-title/widget-title.tsx
@@ -2,6 +2,8 @@ import { HTMLAttributes } from 'react';
 import { type VariantProps, cva } from 'class-variance-authority';
 import classNames from 'classnames/bind';
 
+import { Subtitle } from '@/shared/ui/subtitle';
+
 import styles from './widget-title.module.scss';
 
 type WidgetTitleProps = Pick<HTMLAttributes<HTMLHeadingElement>, 'className' | 'children' | 'id'> &
@@ -29,7 +31,8 @@ const widgetTitleVariants = cva(cx('widget-title'), {
 
 export const WidgetTitle = ({ children, size, mods, className }: WidgetTitleProps) => {
   return (
-    <h2
+    <Subtitle
+      as="h2"
       className={widgetTitleVariants({
         size,
         mods,
@@ -38,6 +41,6 @@ export const WidgetTitle = ({ children, size, mods, className }: WidgetTitleProp
       data-testid="widget-title"
     >
       {children}
-    </h2>
+    </Subtitle>
   );
 };

--- a/src/views/mentorship/ui/mentors-after-register/ui/mentors-after-register.module.scss
+++ b/src/views/mentorship/ui/mentors-after-register/ui/mentors-after-register.module.scss
@@ -17,10 +17,6 @@
         margin: 0;
       }
 
-      &-subtitle {
-        font-weight: $font-weight-bold;
-      }
-
       @include media-tablet {
         gap: 8px;
       }

--- a/src/views/mentorship/ui/mentors-after-register/ui/mentors-after-register.tsx
+++ b/src/views/mentorship/ui/mentors-after-register/ui/mentors-after-register.tsx
@@ -33,11 +33,13 @@ export const MentorsAfterRegister = ({ lang = 'en' }: MentorsAfterRegisterProps)
 
             return (
               <article className={cx('step')} key={step.id} data-testid="after-register-step">
-                <Subtitle className={cx('step-subtitle')} fontSize="small">
+                <Subtitle fontSize="small" weight="bold">
                   {`${id}. ${subtitle}`}
                 </Subtitle>
 
-                <p className={cx('step-content')} data-testid="step-content">{content}</p>
+                <p className={cx('step-content')} data-testid="step-content">
+                  {content}
+                </p>
               </article>
             );
           })}

--- a/src/widgets/member-activity/ui/stage-card/stage-card.scss
+++ b/src/widgets/member-activity/ui/stage-card/stage-card.scss
@@ -17,9 +17,7 @@
     .stage-title {
       margin: 0;
       padding: 0;
-
       font-size: 28px;
-      font-weight: $font-weight-medium;
       line-height: 32px;
 
       @include media-laptop {

--- a/src/widgets/member-activity/ui/stage-card/stage-card.tsx
+++ b/src/widgets/member-activity/ui/stage-card/stage-card.tsx
@@ -5,6 +5,7 @@ import type { StageCardProps } from './stage-card.types';
 import { Step } from './step';
 import { Topics } from './topics';
 import { List } from '@/shared/ui/list';
+import { Subtitle } from '@/shared/ui/subtitle';
 
 import './stage-card.scss';
 
@@ -23,7 +24,9 @@ export const StageCard = ({
     <div className="stage">
       <Step id={id} />
       <div className="stage-info">
-        <h2 className="stage-title">{title}</h2>
+        <Subtitle as="h2" weight="normal" className="stage-title">
+          {title}
+        </Subtitle>
         {description && <p className="stage-description">{description}</p>}
         {links && <Links links={links} />}
         {topics && <Topics topics={topics} />}

--- a/src/widgets/school-menu/ui/school-menu/school-menu.module.scss
+++ b/src/widgets/school-menu/ui/school-menu/school-menu.module.scss
@@ -7,7 +7,6 @@
   .heading {
     margin: 0;
     font-size: 12px;
-    font-weight: $font-weight-medium;
     text-transform: uppercase;
 
     &.dark {

--- a/src/widgets/school-menu/ui/school-menu/school-menu.tsx
+++ b/src/widgets/school-menu/ui/school-menu/school-menu.tsx
@@ -1,6 +1,7 @@
 import { HTMLProps, PropsWithChildren } from 'react';
 import classNames from 'classnames/bind';
 
+import { Subtitle } from '@/shared/ui/subtitle';
 import { Color } from '@/widgets/school-menu/types';
 import { SchoolItem } from '@/widgets/school-menu/ui/school-item/school-item';
 
@@ -17,7 +18,7 @@ type SchoolMenuProps = PropsWithChildren &
 export const SchoolMenu = ({ heading, color = 'light', children, className }: SchoolMenuProps) => {
   return (
     <div className={cx('school-menu')}>
-      {heading && <h3 className={cx('heading', color)}>{heading}</h3>}
+      {heading && <Subtitle weight="normal" className={cx('heading', color)}>{heading}</Subtitle>}
       <ul className={cx('school-list', className)}>{children}</ul>
     </div>
   );


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description
Update Subtitle component  to support heading tags from h2 to h6 (h3 by default). Add tests for new headings level.

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #742 
- Closes #742

## Screenshots, Recordings

_Please replace this line with any relevant images for UI changes._

## Added/updated tests?

- [x] 👌 Yes
- [ ] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the subtitle component to support dynamic heading levels, allowing it to render as different heading styles (`h2`, `h3`, `h4`, `h5`, `h6`) based on a configurable option.
  - Introduced new font weight variants (`light` and `regular`) for subtitle styling.
  
- **Bug Fixes**
  - Improved visual emphasis of the mentor's name and course subtitle by standardizing the use of the subtitle component.

- **Tests**
  - Added comprehensive test cases to ensure the subtitle renders correctly at various heading levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->