### PR TITLE
870-fix: Remove invisible black arrows

### DIFF
--- a/src/shared/ui/link-custom/link-custom.test.tsx
+++ b/src/shared/ui/link-custom/link-custom.test.tsx
@@ -78,7 +78,7 @@ describe('LinkCustom', () => {
     const CustomIcon = () => <div data-testid="custom-icon">custom</div>;
 
     renderWithRouter(
-      <LinkCustom href="/" variant="primary" icon={<CustomIcon />}>
+      <LinkCustom href="/" variant="secondary" icon={<CustomIcon />}>
         {label}
       </LinkCustom>,
     );

--- a/src/shared/ui/link-custom/link-custom.test.tsx
+++ b/src/shared/ui/link-custom/link-custom.test.tsx
@@ -61,18 +61,6 @@ describe('LinkCustom', () => {
     expect(icon).toBeInTheDocument();
   });
 
-  it('renders ArrowIcon when variant is primary', () => {
-    renderWithRouter(
-      <LinkCustom href="/" variant="primary">
-        {label}
-      </LinkCustom>,
-    );
-
-    const icon = screen.getByTestId('arrow-icon');
-
-    expect(icon).toBeInTheDocument();
-  });
-
   it('renders ArrowIcon with small size when variant is rounded', () => {
     renderWithRouter(
       <LinkCustom href="/" variant="rounded">

--- a/src/shared/ui/link-custom/link-custom.test.tsx
+++ b/src/shared/ui/link-custom/link-custom.test.tsx
@@ -61,6 +61,18 @@ describe('LinkCustom', () => {
     expect(icon).toBeInTheDocument();
   });
 
+  it('does not render ArrowIcon when variant is primary', () => {
+    renderWithRouter(
+      <LinkCustom href="/" variant="primary">
+        {label}
+      </LinkCustom>,
+    );
+
+    const icon = screen.queryByTestId('arrow-icon');
+
+    expect(icon).toBeNull();
+  });
+
   it('renders ArrowIcon with small size when variant is rounded', () => {
     renderWithRouter(
       <LinkCustom href="/" variant="rounded">
@@ -78,7 +90,7 @@ describe('LinkCustom', () => {
     const CustomIcon = () => <div data-testid="custom-icon">custom</div>;
 
     renderWithRouter(
-      <LinkCustom href="/" variant="secondary" icon={<CustomIcon />}>
+      <LinkCustom href="/" variant="primary" icon={<CustomIcon />}>
         {label}
       </LinkCustom>,
     );

--- a/src/shared/ui/link-custom/link-custom.tsx
+++ b/src/shared/ui/link-custom/link-custom.tsx
@@ -83,9 +83,10 @@ export const LinkCustom = ({
       {...(external && externalLinkAttributes)}
     >
       {children}
-      <span className={cx('icon-wrapper')}>
-        {!disabled && resolveIcon()}
-      </span>
+      {variant !== 'primary' && (
+        <span className={cx('icon-wrapper')}>
+          {!disabled && resolveIcon()}
+        </span>)}
     </Link>
   );
 };

--- a/src/shared/ui/link-custom/link-custom.tsx
+++ b/src/shared/ui/link-custom/link-custom.tsx
@@ -53,7 +53,7 @@ export const LinkCustom = ({
   highContrast = false,
   ...props
 }: LinkCustomProps) => {
-  const resolveIcon = () => {
+  const resolveIcon = (): ReactNode => {
     switch (true) {
       case external && variant === 'textLink':
         return <TextLinkIcon />;
@@ -64,9 +64,11 @@ export const LinkCustom = ({
       case variant === 'rounded':
         return <ArrowIcon />;
       default:
-        return <></>;
+        return null;
     }
   };
+
+  const IconComponent = resolveIcon();
 
   return (
     <Link
@@ -83,10 +85,7 @@ export const LinkCustom = ({
       {...(external && externalLinkAttributes)}
     >
       {children}
-      {variant !== 'primary' && (
-        <span className={cx('icon-wrapper')}>
-          {!disabled && resolveIcon()}
-        </span>)}
+      {IconComponent && <span className={cx('icon-wrapper')}>{!disabled && IconComponent}</span>}
     </Link>
   );
 };

--- a/src/shared/ui/link-custom/link-custom.tsx
+++ b/src/shared/ui/link-custom/link-custom.tsx
@@ -59,7 +59,6 @@ export const LinkCustom = ({
         return <TextLinkIcon />;
       case icon !== undefined:
         return icon;
-      case variant === 'primary':
       case variant === 'secondary':
         return <ArrowIcon />;
       case variant === 'rounded':


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

- removed invisible black arrows from primary buttons
- remove test that checked for the presence of black arrows on this type of button

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #870
- Closes #870

## Screenshots, Recordings
default state:
![Screenshot 2025-05-07 at 1 19 48 PM](https://github.com/user-attachments/assets/d50ef782-52fc-4006-a8dd-a680b7496598)
hover state:
![Screenshot 2025-05-07 at 1 20 13 PM](https://github.com/user-attachments/assets/93bf04cf-e333-4034-97fd-7147ced9a4cf)

## Added/updated tests?

- [X] 👌 Yes
- [ ] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?


![stimpy-red-button](https://github.com/user-attachments/assets/cef2919e-9372-4576-b656-6e7562a982ae)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the LinkCustom component so that the arrow icon is no longer displayed for the "primary" variant.
- **Tests**
	- Adjusted tests to confirm the absence of the arrow icon for the "primary" variant and improved test descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->