### PR TITLE
841-fix: Docs sidebar overlap

### DIFF
--- a/src/app/docs/components/docs-menu/docs-menu.module.scss
+++ b/src/app/docs/components/docs-menu/docs-menu.module.scss
@@ -1,6 +1,10 @@
 .menu {
   width: 300px;
 
+  > ul {
+    padding-bottom: 15px;
+  }
+
   ul {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

The issue is quite difficult to reproduce. In addition to the steps described in the issue, you also need to enable “Always show scroll bars” in the macOS system settings. Even then, it doesn’t always appear — try restarting your laptop or browser. After refreshing the page, the problem will most likely disappear.

Overall, it seems to be more of a macOS-specific issue, although there are many similar reports online. The simplest solution would be to add some padding so the scrollbar doesn’t cover the content.

## Related Tickets & Documents

- Related Issue #
- Closes #841 

## Screenshots, Recordings


## Added/updated tests?

- [ ] 👌 Yes
- [x] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![image](https://github.com/user-attachments/assets/62874fd6-62a0-4df7-a689-eba6ebbb1128)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Added extra bottom padding to menu lists for improved spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->