### PR TITLE
876-fix: Update paddings for wide screens

### DIFF
--- a/src/core/styles/_mixins.scss
+++ b/src/core/styles/_mixins.scss
@@ -36,6 +36,12 @@
   }
 }
 
+@mixin media-desktop-wide {
+  @media (min-width: #{$content-width + 1px}) {
+    @content;
+  }
+}
+
 @mixin media-hover {
   @media (hover: hover) {
     @content;

--- a/src/widgets/footer/footer.scss
+++ b/src/widgets/footer/footer.scss
@@ -2,7 +2,7 @@
   background-color: $color-black;
 
   &.content {
-    padding: 40px 120px;
+    padding: 40px 80px;
 
     & .desktop-view {
       display: flex;

--- a/src/widgets/header/header.module.scss
+++ b/src/widgets/header/header.module.scss
@@ -46,6 +46,10 @@
   max-width: 1440px;
   height: 100%;
   margin: 0 auto;
+
+  @include media-desktop-wide {
+    max-width: 1280px;
+  }
 }
 
 .navbar-content > .menu {


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description
Aligned header and footer with main content on large screens (>1440px):
- introduced a media-desktop-wide mixin for targeting screens wider than 1440px
- updated header.module.scss to limit the header's width according to the content width
- reduced horizontal padding in the footer to match the main content alignment

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #876 
- Closes #876

## Screenshots, Recordings

<img width="1054" alt="Screenshot 2025-05-13 at 4 21 38 PM" src="https://github.com/user-attachments/assets/74cc3a44-245e-4dce-bfa5-e20085c8970b" />


## Added/updated tests?

- [ ] 👌 Yes
- [X] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![ruler](https://github.com/user-attachments/assets/86ab04c1-3051-43ac-9f96-459602fa8749)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Reduced horizontal padding in the footer for a more compact layout.
  - Adjusted the maximum width of the header navigation bar on wide desktop screens for improved appearance on larger displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->