### PR TITLE
911-fix: Horizontal scroll on some screen sizes

### DIFF
--- a/src/widgets/school-menu/ui/school-menu/school-menu.module.scss
+++ b/src/widgets/school-menu/ui/school-menu/school-menu.module.scss
@@ -24,7 +24,7 @@
     flex-flow: column wrap;
     gap: 19px 40px;
 
-    max-height: 280px;
+    max-height: 360px;
 
     list-style-type: none;
 


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

## Related Tickets & Documents
Increased the maximum height for the school-menu to fit all courses

- Related Issue #911
- Closes #911

## Screenshots, Recordings
![2025-06-04_172910](https://github.com/user-attachments/assets/0e8c7589-4a2e-44ac-950f-6b5ae3acdc3c)


## Added/updated tests?

- [ ] 👌 Yes
- [X] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Increased the maximum height of the school list in the school menu for improved visibility of more items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->