### PR TITLE
996-feat: Fix one of the course labels is vertically misaligned it appears lower than the others in the dropdown list

### DIFF
--- a/src/widgets/school-menu/ui/school-menu/school-menu.module.scss
+++ b/src/widgets/school-menu/ui/school-menu/school-menu.module.scss
@@ -25,8 +25,6 @@
     grid-template-columns: repeat(3, 1fr);
     gap: $gap-l $gap-xl;
 
-    max-height: 438px;
-
     list-style-type: none;
 
     @include media-tablet-large {


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description
One of the course labels is vertically misaligned — it appears lower than the others in the dropdown list

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #996 
- Closes #996 

## Screenshots, Recordings
<img width="942" height="560" alt="image" src="https://github.com/user-attachments/assets/1054ac2e-4b55-461b-91dd-2e4de70e0aa8" />

## Added/updated tests?

- [ ] 👌 Yes
- [x] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * School menu list now dynamically expands to accommodate content instead of being restricted to a fixed height constraint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->