### PR TITLE
fix: 1024 - prevent double ru prefix in doc search URLs

### DIFF
--- a/src/app/docs/components/docs-menu/docs-menu.tsx
+++ b/src/app/docs/components/docs-menu/docs-menu.tsx
@@ -49,7 +49,7 @@ export const DocsMenu = ({ menu, isOpen, onMenuToggle }: DocsMenuProps) => {
         return (
           <li key={index}>
             {doc.link && (
-              <LinkCustom href={resolveHref(doc.link)} className={cx('link', { active: isActive(doc.link) })}>
+              <LinkCustom href={resolveHref(doc.link)} className={cx('link', { active: isActive(doc.link) })} preserveLang={false}>
                 {doc.title}
               </LinkCustom>
             )}
@@ -62,7 +62,7 @@ export const DocsMenu = ({ menu, isOpen, onMenuToggle }: DocsMenuProps) => {
       return (
         doc.link && (
           <li key={index}>
-            <LinkCustom href={resolveHref(doc.link)} className={cx('link', { active: isActive(doc.link) })}>
+            <LinkCustom href={resolveHref(doc.link)} className={cx('link', { active: isActive(doc.link) })} preserveLang={false}>
               {doc.title}
             </LinkCustom>
           </li>

--- a/src/app/docs/components/search/search.tsx
+++ b/src/app/docs/components/search/search.tsx
@@ -195,9 +195,13 @@ function Result({ result, lang }: { result: PagefindSearchResult;
       const { hash, pathname } = urlObj;
       const cleanedPathname = pathname.endsWith('.html') ? pathname.slice(0, -5) : pathname;
 
-      const finalPathname = lang === 'en'
-        ? cleanedPathname.replace('/docs/en/', '/docs/')
-        : cleanedPathname;
+      const alreadyHasLangPrefix = cleanedPathname.startsWith(`/${lang}/`) || cleanedPathname === `/${lang}`;
+      const finalPathname =
+        lang === 'en'
+          ? cleanedPathname.replace('/docs/en/', '/docs/')
+          : alreadyHasLangPrefix
+            ? cleanedPathname
+            : `/${lang}${cleanedPathname}`;
 
       const finalUrl = `${finalPathname}${hash}`;
 
@@ -213,7 +217,7 @@ function Result({ result, lang }: { result: PagefindSearchResult;
 
   return (
     <div>
-      <LinkCustom href={removeHtmlExtension(data.url)} className={cx('link')}>
+      <LinkCustom href={removeHtmlExtension(data.url)} className={cx('link')} preserveLang={false}>
         <Subtitle size="extra-small" weight="bold">{data.meta.title}</Subtitle>
         {/*
           Pagefind excerpts contain highlight <mark> tags.

--- a/src/shared/ui/link-custom/helpers/with-lang.ts
+++ b/src/shared/ui/link-custom/helpers/with-lang.ts
@@ -1,19 +1,10 @@
 import { ROUTES } from '@/shared/constants';
 
 export function withLang(lang: string, path: string) {
-  if (path.startsWith(`/${lang}/`) || path === `/${lang}`) {
-    return path;
-  }
+  const split = path.split('/');
 
-  if (lang === 'en') {
-    return path;
-  }
+  split.unshift(lang);
+  const preparedPath = split.filter(Boolean).join('/');
 
-  if (path === ROUTES.HOME) {
-    return `/${lang}`;
-  }
-
-  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
-
-  return `/${lang}${normalizedPath}`;
+  return path === ROUTES.HOME ? `/${lang}` : `/${preparedPath}`;
 }


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Screenshots, Recordings

_Please replace this line with any relevant images for UI changes._

## Added/updated tests?

- [ ] 👌 Yes
- [ ] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL formatting for non-English documentation pages to prevent duplicate language prefixes.
  * Improved link handling consistency across documentation menu components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->