### PR TITLE
1038-fix: Pagefind cdn caching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Copy Static Assets to S3
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --cache-control max-age=31536000 --exclude '*' --include '_next/*'
+          args: --delete --cache-control max-age=31536000 --exclude '*' --include '_next/*'
         env:
           SOURCE_DIR: 'build'
           DEST_DIR: rs-school
@@ -93,7 +93,7 @@ jobs:
       - name: Copy Pages to S3
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --cache-control max-age=300 --exclude '_next/*'
+          args: --delete --cache-control max-age=300 --exclude '_next/*'
         env:
           SOURCE_DIR: 'build'
           DEST_DIR: rs-school

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:coverage": "vitest run --coverage",
     "precommit": "npx lint-staged",
     "prepare": "husky",
-    "postbuild": "pagefind --force-language ru --site .next/server/app/ru/docs --output-path build/_next/static/pagefind/ru && pagefind --force-language en --site .next/server/app/docs --output-path build/_next/static/pagefind/en",
+    "postbuild": "pagefind --force-language ru --site .next/server/app/ru/docs --output-path build/pagefind/ru && pagefind --force-language en --site .next/server/app/docs --output-path build/pagefind/en",
     "contentful:prepare": "dotenv -e .env -- bash -c 'cf-content-types-generator -e $CONTENTFUL_ENVIRONMENT -X -r -d -s $CONTENTFUL_SPACE_ID -t $CONTENTFUL_MANAGEMENT_TOKEN -o src/shared/types/contentful' && npx eslint src/shared/types/contentful/*.ts --fix && prettier --write src/shared/types/contentful/**/*.ts"
   },
   "engines": {

--- a/src/app/docs/components/search/search.tsx
+++ b/src/app/docs/components/search/search.tsx
@@ -65,7 +65,7 @@ export default function Search({ lang, resultsRef }: SearchProps) {
       try {
         if (!isRunningInDev) {
           window.pagefind = await import(
-            /* webpackIgnore: true */ `/_next/static/pagefind/${lang}/pagefind.js`,
+            /* webpackIgnore: true */ `/pagefind/${lang}/pagefind.js`,
           );
           if (stale) {
             return;


### PR DESCRIPTION
## Summary

- Move Pagefind output from `build/_next/static/pagefind/` to `build/pagefind/` so index files are cached for 5 minutes instead of 1 year
- Update import path in `search.tsx` accordingly
- Add `--delete` to production S3 sync to clean up stale files

## Root cause

Pagefind index files had fixed names but changing content. Being inside `_next/static/`, they were uploaded with `max-age=31536000` (1 year). Different CloudFront edge nodes cached different versions, causing search to work for one language but not the other depending on user location (VPN vs no VPN).

## Test plan

- [ ] Verify production build generates pagefind files in `build/pagefind/`
- [ ] Verify search works for both EN and RU after deploy
- [ ] Verify other static assets (`_next/*`) are unaffected

Closes #1038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined deployment workflow to remove unused files from storage
  * Updated asset delivery configuration for search functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->