### PR TITLE
1050-fix: Fix undefined subtitle for angular course in course card

### DIFF
--- a/src/entities/course/ui/course-card/course-card.test.tsx
+++ b/src/entities/course/ui/course-card/course-card.test.tsx
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { CourseCard } from './course-card';
 import { mockedCourses } from '@/shared/__tests__/constants';
 import { renderWithRouter } from '@/shared/__tests__/utils';
-import { COURSE_TITLES } from '@/shared/constants';
 
 describe('CourseCard', () => {
   describe.each(mockedCourses)('Testing course card $title', (course) => {
@@ -21,8 +20,9 @@ describe('CourseCard', () => {
 
     it('renders the course card content correctly', () => {
       const language = course.language.has('ru') ? 'Русский' : 'English';
-      const mark =
-        course.title === COURSE_TITLES.ANGULAR && course.subTitle ? ` (${course.subTitle})` : '';
+      const mark = !course.showMentoringStartDate && course.subTitle
+        ? ` (${course.subTitle})`
+        : '';
       const title = `${course.title}${mark}`;
 
       expect(screen.getByText(title)).toBeVisible();

--- a/src/entities/course/ui/course-card/course-card.test.tsx
+++ b/src/entities/course/ui/course-card/course-card.test.tsx
@@ -20,9 +20,7 @@ describe('CourseCard', () => {
 
     it('renders the course card content correctly', () => {
       const language = course.language.has('ru') ? 'Русский' : 'English';
-      const mark = !course.showMentoringStartDate && course.subTitle
-        ? ` (${course.subTitle})`
-        : '';
+      const mark = course.subTitle ? ` (${course.subTitle})` : '';
       const title = `${course.title}${mark}`;
 
       expect(screen.getByText(title)).toBeVisible();

--- a/src/entities/course/ui/course-card/course-card.test.tsx
+++ b/src/entities/course/ui/course-card/course-card.test.tsx
@@ -21,7 +21,9 @@ describe('CourseCard', () => {
 
     it('renders the course card content correctly', () => {
       const language = course.language.has('ru') ? 'Русский' : 'English';
-      const title = `${course.title}${course.title === COURSE_TITLES.ANGULAR ? ` (${course.subTitle})` : ''}`;
+      const mark =
+        course.title === COURSE_TITLES.ANGULAR && course.subTitle ? ` (${course.subTitle})` : '';
+      const title = `${course.title}${mark}`;
 
       expect(screen.getByText(title)).toBeVisible();
       expect(screen.getByText(language)).toBeVisible();

--- a/src/entities/course/ui/course-card/course-card.tsx
+++ b/src/entities/course/ui/course-card/course-card.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image';
 import { useParams } from 'next/navigation';
 
 import type { Course } from '../../types';
-import { COURSE_TITLES, LABELS } from '@/shared/constants';
+import { LABELS } from '@/shared/constants';
 import { ApiResourceLocale } from '@/shared/types';
 import { LinkCustom } from '@/shared/ui/link-custom';
 import { ShortInfoPanel } from '@/shared/ui/short-info-panel';
@@ -37,7 +37,7 @@ export type CourseCardProps = Pick<
 
 export const CourseCard = ({
   title,
-  subTitle,
+  subTitle = '',
   iconSrc,
   startDate,
   registrationEndDate,
@@ -58,8 +58,7 @@ export const CourseCard = ({
   const dateLabel = size === 'sm' ? LABELS[lang].START_DATE_SHORT : LABELS[lang].START_DATE;
   const fontSize = size === 'md' ? 'large' : 'small';
 
-  const mark =
-    title === COURSE_TITLES.ANGULAR && !showMentoringStartDate && subTitle ? ` (${subTitle})` : '';
+  const mark = !showMentoringStartDate && subTitle ? ` (${subTitle})` : '';
   const classes = {
     [`size-${size}`]: true,
     [className]: true,

--- a/src/entities/course/ui/course-card/course-card.tsx
+++ b/src/entities/course/ui/course-card/course-card.tsx
@@ -58,7 +58,8 @@ export const CourseCard = ({
   const dateLabel = size === 'sm' ? LABELS[lang].START_DATE_SHORT : LABELS[lang].START_DATE;
   const fontSize = size === 'md' ? 'large' : 'small';
 
-  const mark = title === COURSE_TITLES.ANGULAR && !showMentoringStartDate ? ` (${subTitle})` : '';
+  const mark =
+    title === COURSE_TITLES.ANGULAR && !showMentoringStartDate && subTitle ? ` (${subTitle})` : '';
   const classes = {
     [`size-${size}`]: true,
     [className]: true,

--- a/src/widgets/external-embed-content/ui/courses/courses.test.tsx
+++ b/src/widgets/external-embed-content/ui/courses/courses.test.tsx
@@ -19,7 +19,8 @@ describe('Courses (other courses) component', () => {
 
     courseTitles.forEach((title) => {
       const course = mockedCourses.find((c) => {
-        const mark = c.title === COURSE_TITLES.ANGULAR ? ` (${c.subTitle})` : '';
+        const mark =
+          c.title === COURSE_TITLES.ANGULAR && c.subTitle ? ` (${c.subTitle})` : '';
 
         return `${c.title}${mark}` === title.textContent;
       });

--- a/src/widgets/external-embed-content/ui/courses/courses.test.tsx
+++ b/src/widgets/external-embed-content/ui/courses/courses.test.tsx
@@ -18,7 +18,7 @@ describe('Courses (other courses) component', () => {
 
     courseTitles.forEach((title) => {
       const course = mockedCourses.find((c) => {
-        const mark = !c.showMentoringStartDate && c.subTitle ? ` (${c.subTitle})` : '';
+        const mark = c.subTitle ? ` (${c.subTitle})` : '';
 
         return `${c.title}${mark}` === title.textContent;
       });

--- a/src/widgets/external-embed-content/ui/courses/courses.test.tsx
+++ b/src/widgets/external-embed-content/ui/courses/courses.test.tsx
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 
 import { Courses } from './courses';
 import { mockedCourses } from '@/shared/__tests__/constants';
-import { COURSE_TITLES } from '@/shared/constants';
 
 describe('Courses (other courses) component', () => {
   it('renders widget without crashing and display correct content', () => {
@@ -19,8 +18,7 @@ describe('Courses (other courses) component', () => {
 
     courseTitles.forEach((title) => {
       const course = mockedCourses.find((c) => {
-        const mark =
-          c.title === COURSE_TITLES.ANGULAR && c.subTitle ? ` (${c.subTitle})` : '';
+        const mark = !c.showMentoringStartDate && c.subTitle ? ` (${c.subTitle})` : '';
 
         return `${c.title}${mark}` === title.textContent;
       });


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue  https://github.com/rolling-scopes/site/issues/1050
- Closes #

## Screenshots, Recordings

_Please replace this line with any relevant images for UI changes._

## Added/updated tests?

- [ ] 👌 Yes
- [ ] 🙅‍♂️ No, because they aren't needed
- [ ] 🙋‍♂️ No, because I need help

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Course card titles now append subtitles in parentheses only when a subtitle exists; empty subtitle indicators no longer appear.
* **Tests**
  * Updated test cases to reflect and validate the new subtitle-in-title behavior consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->