### PR TITLE
309-feat: Display event data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ LOG_QUERY=true
 # RS App
 NEXT_PUBLIC_RS_APP_API_BASE_URL=https://cdn.rs.school
 
+# Events
+NEXT_PUBLIC_EVENTS_JSON_URL=
+
 # YouTube
 NEXT_PUBLIC_YOUTUBE_API_BASE_URL=https://www.googleapis.com/youtube/v3
 NEXT_PUBLIC_YOUTUBE_API_KEY=YOUTUBE_API_KEY

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ LOG_QUERY=true
 NEXT_PUBLIC_RS_APP_API_BASE_URL=https://cdn.rs.school
 
 # Events
-NEXT_PUBLIC_EVENTS_JSON_URL=
+NEXT_PUBLIC_EVENTS_JSON_URL=https://cdn.rs.school/events.json
 
 # YouTube
 NEXT_PUBLIC_YOUTUBE_API_BASE_URL=https://www.googleapis.com/youtube/v3

--- a/src/entities/event/index.ts
+++ b/src/entities/event/index.ts
@@ -1,2 +1,2 @@
-export type { Event } from './types';
+export type { Event, EventRecord } from './types';
 export { EventCard } from './ui/event-card/event-card';

--- a/src/entities/event/model/store.ts
+++ b/src/entities/event/model/store.ts
@@ -1,0 +1,62 @@
+import type { EventRecord } from '../types';
+
+type EventsOutput = {
+  upcomingEvents: EventRecord[];
+};
+
+const eventStringFields = [
+  'eventType',
+  'title',
+  'organizedBy',
+  'organization',
+  'date',
+  'time',
+  'type',
+  'address',
+  'city',
+  'href',
+] as const;
+
+function isEventRecord(value: unknown): value is EventRecord {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const event = value as Record<string, unknown>;
+
+  return (
+    typeof event.id === 'number'
+    && eventStringFields.every((field) => typeof event[field] === 'string')
+    && (event.additionalInfo === undefined || typeof event.additionalInfo === 'string')
+  );
+}
+
+function isEventsOutput(value: unknown): value is EventsOutput {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const output = value as Record<string, unknown>;
+
+  return Array.isArray(output.upcomingEvents) && output.upcomingEvents.every(isEventRecord);
+}
+
+class EventStore {
+  public loadUpcomingEvents = async (url: string) => {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error('Error while loading events.');
+    }
+
+    const output: unknown = await response.json();
+
+    if (!isEventsOutput(output)) {
+      throw new Error('Invalid events response.');
+    }
+
+    return output.upcomingEvents;
+  };
+}
+
+export const eventStore = new EventStore();

--- a/src/entities/event/types.ts
+++ b/src/entities/event/types.ts
@@ -11,3 +11,7 @@ export type Event = {
   city: string;
   href: string;
 };
+
+export type EventRecord = Event & {
+  id: number;
+};

--- a/src/widgets/events/index.ts
+++ b/src/widgets/events/index.ts
@@ -1,0 +1,1 @@
+export { EventsSection } from './ui/events-section/events-section';

--- a/src/widgets/events/ui/events-section/events-section.module.scss
+++ b/src/widgets/events/ui/events-section/events-section.module.scss
@@ -1,0 +1,10 @@
+.event-cards {
+  display: flex;
+  gap: $gap-s;
+  align-items: center;
+  justify-content: space-between;
+
+  @include media-tablet {
+    flex-direction: column;
+  }
+}

--- a/src/widgets/events/ui/events-section/events-section.test.tsx
+++ b/src/widgets/events/ui/events-section/events-section.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { EventsSection } from './events-section';
+
+const event = {
+  id: 1,
+  eventType: 'Meetup',
+  title: 'RS School Meetup',
+  organizedBy: 'Online',
+  organization: 'The Rolling Scopes',
+  date: '2026-09-05',
+  time: '11:00 UTC',
+  type: 'Online',
+  address: 'Online',
+  city: '',
+  href: 'https://example.com/event',
+};
+
+const fallback = <div data-testid="events-fallback">Event photo</div>;
+
+function mockResponse(body: unknown, ok = true) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok,
+      json: vi.fn().mockResolvedValue(body),
+    }),
+  );
+}
+
+describe('EventsSection', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('shows the Contentful fallback without a configured URL', () => {
+    const fetchMock = vi.fn();
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<EventsSection eventsUrl="" fallback={fallback} />);
+
+    expect(screen.getByTestId('events-fallback')).toBeVisible();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('replaces the fallback with up to two valid upcoming events', async () => {
+    mockResponse({
+      upcomingEvents: [
+        event,
+        {
+          ...event,
+          id: 2,
+        },
+        {
+          ...event,
+          id: 3,
+        },
+      ],
+    });
+
+    render(<EventsSection eventsUrl="https://cdn.example.com/events.json" fallback={fallback} />);
+
+    expect(screen.getByTestId('events-fallback')).toBeVisible();
+    await waitFor(() => expect(screen.getAllByTestId('event-card')).toHaveLength(2));
+    expect(screen.queryByTestId('events-fallback')).not.toBeInTheDocument();
+  });
+
+  it('keeps the fallback when there are no upcoming events', async () => {
+    mockResponse({ upcomingEvents: [] });
+
+    render(
+      <EventsSection eventsUrl="https://cdn.example.com/no-events.json" fallback={fallback} />,
+    );
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    expect(screen.getByTestId('events-fallback')).toBeVisible();
+  });
+
+  it('keeps the fallback when the response is invalid', async () => {
+    mockResponse({ upcomingEvents: [{ id: 1 }] });
+
+    render(<EventsSection eventsUrl="https://cdn.example.com/invalid.json" fallback={fallback} />);
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    expect(screen.getByTestId('events-fallback')).toBeVisible();
+  });
+});

--- a/src/widgets/events/ui/events-section/events-section.test.tsx
+++ b/src/widgets/events/ui/events-section/events-section.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { EventsSection } from './events-section';
@@ -68,22 +68,52 @@ describe('EventsSection', () => {
   });
 
   it('keeps the fallback when there are no upcoming events', async () => {
-    mockResponse({ upcomingEvents: [] });
+    let resolveJson!: (value: unknown) => void;
+    const json = new Promise((resolve) => {
+      resolveJson = resolve;
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockReturnValue(json),
+      }),
+    );
 
     render(
       <EventsSection eventsUrl="https://cdn.example.com/no-events.json" fallback={fallback} />,
     );
 
     await waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    await act(async () => {
+      resolveJson({ upcomingEvents: [] });
+      await json;
+    });
     expect(screen.getByTestId('events-fallback')).toBeVisible();
   });
 
   it('keeps the fallback when the response is invalid', async () => {
-    mockResponse({ upcomingEvents: [{ id: 1 }] });
+    let resolveJson!: (value: unknown) => void;
+    const json = new Promise((resolve) => {
+      resolveJson = resolve;
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockReturnValue(json),
+      }),
+    );
 
     render(<EventsSection eventsUrl="https://cdn.example.com/invalid.json" fallback={fallback} />);
 
     await waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    await act(async () => {
+      resolveJson({ upcomingEvents: [{ id: 1 }] });
+      await json;
+    });
     expect(screen.getByTestId('events-fallback')).toBeVisible();
   });
 });

--- a/src/widgets/events/ui/events-section/events-section.tsx
+++ b/src/widgets/events/ui/events-section/events-section.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { ReactNode } from 'react';
+import useSWR from 'swr';
+
+import { EventCard } from '@/entities/event';
+import { eventStore } from '@/entities/event/model/store';
+
+import styles from './events-section.module.scss';
+
+type EventsSectionProps = {
+  fallback?: ReactNode;
+  eventsUrl?: string;
+};
+
+export const EventsSection = ({
+  fallback,
+  eventsUrl = process.env.NEXT_PUBLIC_EVENTS_JSON_URL,
+}: EventsSectionProps) => {
+  const { data: events } = useSWR(eventsUrl || null, eventStore.loadUpcomingEvents);
+  const nearestEvents = events?.slice(0, 2) ?? [];
+
+  if (nearestEvents.length === 0) {
+    return fallback;
+  }
+
+  return (
+    <div className={styles['event-cards']}>
+      {nearestEvents.map((event) => (
+        <EventCard key={event.id} {...event} />
+      ))}
+    </div>
+  );
+};

--- a/src/widgets/section-resolver/section-resolver.tsx
+++ b/src/widgets/section-resolver/section-resolver.tsx
@@ -1,6 +1,7 @@
 import { Marquee } from '../marquee';
 import { courseStore } from '@/entities/course';
 import { MentorFeedbackCard } from '@/entities/mentor';
+import { ANCHORS } from '@/shared/constants';
 import { isExternalUri } from '@/shared/helpers/is-external-uri';
 import { Section } from '@/shared/types/types';
 import { LinkCustom } from '@/shared/ui/link-custom';
@@ -8,6 +9,7 @@ import { LINK_TYPE } from '@/shared/ui/link-custom/constants';
 import { Slider } from '@/shared/ui/slider';
 import { communitySliderOptions, mentorshipSliderOptions } from '@/shared/ui/slider/constants';
 import { SocialMediaLink } from '@/shared/ui/social-media-link';
+import { EventsSection } from '@/widgets/events';
 import {
   EXTERNAL_EMBED_CONTENT_TYPE,
   MentorTalksVideoPlaylistWithPlayer,
@@ -88,7 +90,11 @@ export const SectionResolver = async ({
           titleMod={section.data.titleMod}
           sectionLabel={section.data.sectionLabel}
           contentLeft={section.data.contentLeft}
-          contentRight={section.data.contentRight}
+          contentRight={
+            section.data.anchorId === ANCHORS.EVENTS
+              ? <EventsSection fallback={section.data.contentRight} />
+              : section.data.contentRight
+          }
           contentBottom={section.data.contentBottom}
           backgroundColor={section.data.backgroundColor}
           width={section.data.width}


### PR DESCRIPTION
## What type of PR is this? (select all that apply)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🚧 Breaking Change
- [ ] 🧑‍💻 Code Refactor
- [ ] 📝 Documentation Update

## Description

Configure the site to load upcoming event data from the CDN and document the required public events feed environment variable.

## Related Tickets & Documents

- Related Issue #309
- Related Backend PR: [ivmoskalev/rs-events#1](https://github.com/ivmoskalev/rs-events/pull/1)

The frontend and backend changes are connected. Issue #309 can be closed after both parts are finalized and merged, including the AWS Lambda implementation.

## Screenshots, Recordings

<img width="1622" height="740" alt="image" src="https://github.com/user-attachments/assets/fda07387-4cf0-43c9-ba63-3cda0f4ee0ba" />

## Added/updated tests?

- [x] 👌 Yes

The existing test suite passed: 51 test files and 258 tests. The production build also completed successfully.

## [optional] Are there any post deployment tasks we need to perform?

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Events section that displays up to two upcoming events.
  * Added a configurable endpoint for loading event data.
  * Added responsive event card layout with tablet-friendly stacking.
  * Added validation for event data before display.
  * Preserves existing section content when event data is unavailable, invalid, or requests fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->